### PR TITLE
[iOS/#8] 홈 화면 게시글 등록 Floating Button 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		44425A642B038AEA00AAD64A /* FloatingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44425A632B038AEA00AAD64A /* FloatingButton.swift */; };
 		5975E98A2B035919007CEF13 /* Post.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9872B035919007CEF13 /* Post.json */; };
 		5975E98B2B035919007CEF13 /* Posts.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9882B035919007CEF13 /* Posts.json */; };
 		5975E98C2B035919007CEF13 /* Users.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9892B035919007CEF13 /* Users.json */; };
@@ -28,6 +29,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		44425A632B038AEA00AAD64A /* FloatingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButton.swift; sourceTree = "<group>"; };
 		5975E9872B035919007CEF13 /* Post.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Post.json; sourceTree = "<group>"; };
 		5975E9882B035919007CEF13 /* Posts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Posts.json; sourceTree = "<group>"; };
 		5975E9892B035919007CEF13 /* Users.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Users.json; sourceTree = "<group>"; };
@@ -59,6 +61,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		44425A622B038AA700AAD64A /* CustomView */ = {
+			isa = PBXGroup;
+			children = (
+				44425A632B038AEA00AAD64A /* FloatingButton.swift */,
+			);
+			path = CustomView;
+			sourceTree = "<group>";
+		};
 		5975E98D2B03591E007CEF13 /* Data */ = {
 			isa = PBXGroup;
 			children = (
@@ -126,6 +136,7 @@
 		8FBE3AED2B03549300660530 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				44425A622B038AA700AAD64A /* CustomView */,
 				59E0C5FF2AFBA3FC0073D494 /* ViewController.swift */,
 			);
 			path = Presentation;
@@ -276,6 +287,7 @@
 				59E0C6002AFBA3FC0073D494 /* ViewController.swift in Sources */,
 				59E0C5FC2AFBA3FC0073D494 /* AppDelegate.swift in Sources */,
 				59E0C5FE2AFBA3FC0073D494 /* SceneDelegate.swift in Sources */,
+				44425A642B038AEA00AAD64A /* FloatingButton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iOS/Village/Village/Presentation/CustomView/FloatingButton.swift
+++ b/iOS/Village/Village/Presentation/CustomView/FloatingButton.swift
@@ -1,0 +1,78 @@
+//
+//  FloatingButton.swift
+//  Village
+//
+//  Created by 정상윤 on 11/14/23.
+//
+
+import UIKit
+
+final class FloatingButton: UIButton {
+    
+    private var toggle = false {
+        didSet {
+            updateUI()
+        }
+    }
+    
+    init() {
+        super.init(frame: CGRect(x: 0, y: 0, width: 65, height: 65))
+        
+        self.layer.cornerRadius = 32.5
+        self.backgroundColor = .primary500
+        self.tintColor = .white
+        
+        setImage()
+    }
+    
+    private override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    func trigger() {
+        toggle.toggle()
+    }
+    
+}
+
+// MARK: - UI
+
+private extension FloatingButton {
+    
+    func updateUI() {
+        switch toggle {
+        case true:
+            toggleOn()
+        case false:
+            toggleOff()
+        }
+    }
+    
+    func toggleOn() {
+        self.backgroundColor = .grey800
+        
+        UIView.transition(with: self, duration: 0.3) {
+            self.transform = .init(rotationAngle: .pi/4)
+        }
+    }
+    
+    func toggleOff() {
+        self.backgroundColor = .primary500
+        
+        UIView.transition(with: self, duration: 0.3) {
+            self.transform = .init(rotationAngle: 0)
+        }
+    }
+    
+    func setImage() {
+        let imageName = "plus"
+        let config = UIImage.SymbolConfiguration(pointSize: 40, weight: .light)
+        let plusImage = UIImage(systemName: imageName, withConfiguration: config)
+        
+        self.setImage(plusImage, for: .normal)
+    }
+}

--- a/iOS/Village/Village/Presentation/CustomView/FloatingButton.swift
+++ b/iOS/Village/Village/Presentation/CustomView/FloatingButton.swift
@@ -6,23 +6,31 @@
 //
 
 import UIKit
+import Combine
 
 final class FloatingButton: UIButton {
     
-    private var toggle = false {
-        didSet {
-            updateUI()
+    @Published var toggle = false {
+        willSet {
+            switch newValue {
+            case true:
+                toggleOn()
+            case false:
+                toggleOff()
+            }
         }
     }
     
-    init() {
-        super.init(frame: CGRect(x: 0, y: 0, width: 65, height: 65))
+    init(imageName: String = "plus", frame: CGRect) {
+        super.init(frame: frame)
+        
+        addAction(.init { [weak self] _ in self?.toggle.toggle()}, for: .touchUpInside)
         
         self.layer.cornerRadius = 32.5
         self.backgroundColor = .primary500
         self.tintColor = .white
         
-        setImage()
+        setImage(imageName: imageName)
     }
     
     private override init(frame: CGRect) {
@@ -33,46 +41,33 @@ final class FloatingButton: UIButton {
         super.init(coder: coder)
     }
     
-    func trigger() {
-        toggle.toggle()
-    }
-    
 }
 
 // MARK: - UI
 
 private extension FloatingButton {
     
-    func updateUI() {
-        switch toggle {
-        case true:
-            toggleOn()
-        case false:
-            toggleOff()
-        }
-    }
-    
     func toggleOn() {
         self.backgroundColor = .grey800
-        
-        UIView.transition(with: self, duration: 0.3) {
-            self.transform = .init(rotationAngle: .pi/4)
+
+        UIView.transition(with: self, duration: 0.2) {
+            self.transform = CGAffineTransform(rotationAngle: .pi/4)
         }
     }
     
     func toggleOff() {
         self.backgroundColor = .primary500
-        
-        UIView.transition(with: self, duration: 0.3) {
-            self.transform = .init(rotationAngle: 0)
+
+        UIView.transition(with: self, duration: 0.2) {
+            self.transform = CGAffineTransform(rotationAngle: 0)
         }
     }
     
-    func setImage() {
-        let imageName = "plus"
+    func setImage(imageName: String) {
         let config = UIImage.SymbolConfiguration(pointSize: 40, weight: .light)
         let plusImage = UIImage(systemName: imageName, withConfiguration: config)
         
         self.setImage(plusImage, for: .normal)
     }
+
 }


### PR DESCRIPTION
## 이슈
- close #8 

## 체크리스트
- [x] Presentation에 CustomView 그룹 추가
- [x] UIButton을 상속 받아 Floating Button 구현

## 고민한 내용
- UIButton을 상속 받을지 UIView를 상속 받을지 고민했습니다. Floating Button은 특수한 UIButton이라고 생각해서 UIButton을 상속 받는 것으로 결정했습니다.
- Floating Button의 생김새 변화 코드는 버튼 자체의 기능이기 때문에 상위에서 addTarget하는 로직에서 내부에서 addAction하도록 수정했습니다. addAction을 사용한 이유는 코드가 간단하기 때문에 별도의 @objc 함수를 선언하지 않고 클로저로 바로 넣기 위함입니다.
- 많은 고민 끝에 버튼이 눌렸을 때 표시될 메뉴를 표시/숨기기 하는 것은 상위 뷰 컨트롤러에서의 책임이라고 생각했습니다. 버튼은 상위에 대한 정보를 몰라야 하기 때문입니다. 그래서 버튼의 트리거 값에 따른 동작을 상위에서 정의할 수 있도록 @Published 프로퍼티 래퍼를 통해 toggle 값을 구독하여 반응할 수 있도록 코드를 작성했습니다.

## 스크린샷
- 임시 동작 확인 
    <image src="https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/3f62a223-8385-4c34-8ec9-a3c0edcc8146" width="300" />
