### PR TITLE
[iOS/#8] 홈 화면 게시글 등록 Floating Button 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		440FCC2D2B04EB940011B637 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440FCC2C2B04EB940011B637 /* Constants.swift */; };
 		44425A642B038AEA00AAD64A /* FloatingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44425A632B038AEA00AAD64A /* FloatingButton.swift */; };
+		4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491AA272B05D6C90016FC70 /* MenuView.swift */; };
 		5975E98A2B035919007CEF13 /* Post.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9872B035919007CEF13 /* Post.json */; };
 		5975E98B2B035919007CEF13 /* Posts.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9882B035919007CEF13 /* Posts.json */; };
 		5975E98C2B035919007CEF13 /* Users.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9892B035919007CEF13 /* Users.json */; };
@@ -38,6 +39,7 @@
 /* Begin PBXFileReference section */
 		440FCC2C2B04EB940011B637 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		44425A632B038AEA00AAD64A /* FloatingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButton.swift; sourceTree = "<group>"; };
+		4491AA272B05D6C90016FC70 /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
 		5975E9872B035919007CEF13 /* Post.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Post.json; sourceTree = "<group>"; };
 		5975E9882B035919007CEF13 /* Posts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Posts.json; sourceTree = "<group>"; };
 		5975E9892B035919007CEF13 /* Users.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Users.json; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 			isa = PBXGroup;
 			children = (
 				44425A632B038AEA00AAD64A /* FloatingButton.swift */,
+				4491AA272B05D6C90016FC70 /* MenuView.swift */,
 			);
 			path = CustomView;
 			sourceTree = "<group>";
@@ -346,6 +349,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */,
+				4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */,
 				8FBE3B122B04CF6300660530 /* UILabel+SetTitle.swift in Sources */,
 				8FBE3B0A2B0478D400660530 /* HomeCollectionViewCell.swift in Sources */,
 				440FCC2D2B04EB940011B637 /* Constants.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -168,10 +168,10 @@
 		8FBE3AED2B03549300660530 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				44425A622B038AA700AAD64A /* CustomView */,
 				8FBE3B0D2B04CB8100660530 /* Utils */,
 				8FBE3B062B04763200660530 /* Home */,
 				59E196C72B045EFA00BF7C5A /* PostingRent */,
-				44425A622B038AA700AAD64A /* CustomView */,
 				59E0C5FF2AFBA3FC0073D494 /* ViewController.swift */,
 			);
 			path = Presentation;

--- a/iOS/Village/Village/Presentation/CustomView/MenuView.swift
+++ b/iOS/Village/Village/Presentation/CustomView/MenuView.swift
@@ -1,0 +1,89 @@
+//
+//  MenuView.swift
+//  Village
+//
+//  Created by 정상윤 on 11/16/23.
+//
+
+import UIKit
+
+final class MenuView: UIView {
+    
+    private var menuStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.distribution = .fillEqually
+        return stackView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+        setupUI()
+    }
+    
+    func setMenuActions(_ actions: [UIAction]) {
+        updateMenuButton(actions: actions)
+    }
+    
+    private func setupUI() {
+        self.alpha = 0
+        self.layer.cornerRadius = 12
+        self.layer.masksToBounds = true
+        self.addSubview(menuStackView)
+        setMenuStackViewLayoutConstraint()
+    }
+    
+    private func updateMenuButton(actions: [UIAction]) {
+        menuStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+        
+        actions.forEach { action in
+            var configuration = UIButton.Configuration.plain()
+            configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 0)
+            let button = UIButton(configuration: configuration, primaryAction: action)
+            
+            button.setTitle(action.title, for: .normal)
+            button.backgroundColor = .grey800
+            button.tintColor = .white
+            button.contentHorizontalAlignment = .leading
+            button.titleLabel?.font = .preferredFont(forTextStyle: .title2)
+            
+            menuStackView.addArrangedSubview(button)
+        }
+    }
+    
+    private func setMenuStackViewLayoutConstraint() {
+        NSLayoutConstraint.activate([
+            menuStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0),
+            menuStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: 0),
+            menuStackView.topAnchor.constraint(equalTo: topAnchor, constant: 0),
+            menuStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0)
+        ])
+    }
+    
+}
+
+// MARK: - Fade In & Out
+extension MenuView {
+    
+    func fadeIn() {
+        self.isHidden = false
+        UIView.transition(with: self, duration: 0.2) {
+            self.alpha = 1
+        }
+    }
+    
+    func fadeOut() {
+        UIView.transition(with: self, duration: 0.2) {
+            self.alpha = 0
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/Home/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/HomeViewController.swift
@@ -15,6 +15,12 @@ final class HomeViewController: UIViewController {
     private let reuseIdentifier = HomeCollectionViewCell.identifier
     private var collectionView: UICollectionView!
     
+    private let floatingButton: FloatingButton = {
+        let button = FloatingButton(frame: .zero)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
     enum Section {
         case main
     }
@@ -22,10 +28,17 @@ final class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setupUI()
+        generateData()
+    }
+    
+    private func setupUI() {
         setNavigationUI()
         configureCollectionView()
         configureDataSource()
-        generateData()
+        
+        view.addSubview(floatingButton)
+        setLayoutConstraint()
     }
     
     private func setNavigationUI() {
@@ -93,5 +106,14 @@ final class HomeViewController: UIViewController {
         
         snapshot.appendItems(items)
         dataSource.apply(snapshot, animatingDifferences: true)
+    }
+    
+    private func setLayoutConstraint() {
+        NSLayoutConstraint.activate([
+            floatingButton.widthAnchor.constraint(equalToConstant: 65),
+            floatingButton.heightAnchor.constraint(equalToConstant: 65),
+            floatingButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
+            floatingButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
+        ])
     }
 }

--- a/iOS/Village/Village/Presentation/Home/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/HomeViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 final class HomeViewController: UIViewController {
     
@@ -21,6 +22,15 @@ final class HomeViewController: UIViewController {
         return button
     }()
     
+    private let menuView: MenuView = {
+        let menu = MenuView()
+        menu.isHidden = true
+        menu.translatesAutoresizingMaskIntoConstraints = false
+        return menu
+    }()
+    
+    private var cancellableBag = Set<AnyCancellable>()
+    
     enum Section {
         case main
     }
@@ -28,16 +38,29 @@ final class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        floatingButton.$isActive
+            .sink(receiveValue: { [weak self] isActive in
+                switch isActive {
+                case true:
+                    self?.menuView.fadeIn()
+                case false:
+                    self?.menuView.fadeOut()
+                }
+            })
+            .store(in: &cancellableBag)
+        
         setupUI()
         generateData()
     }
     
     private func setupUI() {
         setNavigationUI()
+        setMenuUI()
         configureCollectionView()
         configureDataSource()
         
         view.addSubview(floatingButton)
+        view.addSubview(menuView)
         setLayoutConstraint()
     }
     
@@ -50,6 +73,16 @@ final class HomeViewController: UIViewController {
         )
         self.navigationItem.rightBarButtonItems = [search]
         
+    }
+    
+    private func setMenuUI() {
+        let postRequestAction = UIAction(title: "대여 요청하기") { _ in
+            // TODO: 요청 게시글 화면 이동
+        }
+        let postRentAction = UIAction(title: "대여 등록하기") { _ in
+            // TODO: 등록 게시글 화면 이동
+        }
+        menuView.setMenuActions([postRequestAction, postRentAction])
     }
     
     @objc func search() {
@@ -114,6 +147,13 @@ final class HomeViewController: UIViewController {
             floatingButton.heightAnchor.constraint(equalToConstant: 65),
             floatingButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -20),
             floatingButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
+        ])
+        
+        NSLayoutConstraint.activate([
+            menuView.widthAnchor.constraint(equalToConstant: 150),
+            menuView.heightAnchor.constraint(equalToConstant: 100),
+            menuView.trailingAnchor.constraint(equalTo: floatingButton.trailingAnchor, constant: 0),
+            menuView.bottomAnchor.constraint(equalTo: floatingButton.topAnchor, constant: -15)
         ])
     }
 }

--- a/iOS/Village/Village/Resources/Assets.xcassets/Grey-100.colorset/Contents.json
+++ b/iOS/Village/Village/Resources/Assets.xcassets/Grey-100.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEB",
+          "green" : "0xE7",
+          "red" : "0xE3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 이슈
- #8 

## 체크리스트
- [x] HomeViewController에 floatingButton 추가
- [x] floatingButton 오토 레이아웃 설정
- [x] Grey-100 Color Set 추가
- [x] MenuView 커스텀 뷰 구현
- [x] HomeViewController에 menuView 추가
- [x] FloatingButton isActive 구독하여 요청/대여 게시글 등록 메뉴 표시 동작 구현

## 고민한 내용
- MenuView의 페이드 인/아웃 동작을 `extension UIView`로 재사용 가능한 메서드로 할지 고민하다 다른 화면에서 사용될 여지는 아직 보이지 않아 MenuView 자체 메서드로 두었습니다.
- UIEdgeInsets가 iOS15부터 deprecated 될 것이기 때문에 `UIButton.Configuration.contentInsets`를 통해 leading 마진을 넣었습니다.
- `UIButton.Configuration`을 통해 생성한 UIButton은 `button.titleLabel?.font`문을 통한 폰트 변경이 불가했습니다. 이 부분은 추가적으로 조사 후 구현해보도록 하겠습니다.

## 스크린샷
https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/6c55e067-bc36-4e7d-905d-980879485227