### PR TITLE
[iOS/#70] 홈 화면 대여 게시글 등록 화면으로 이동

### DIFF
--- a/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
@@ -99,10 +99,10 @@ final class HomeViewController: UIViewController {
         let presentPostRequestVC = UIAction(title: "대여 요청하기") { _ in
             // TODO: 요청 게시글 화면 이동
         }
-        let presentPostRentVC = UIAction(title: "대여 등록하기") { _ in
+        let presentPostRentVC = UIAction(title: "대여 등록하기") { [weak self] _ in
             let postRentVC = PostingRentViewController()
             postRentVC.modalPresentationStyle = .fullScreen
-            self.present(postRentVC, animated: true)
+            self?.present(postRentVC, animated: true)
         }
         menuView.setMenuActions([presentPostRequestVC, presentPostRentVC])
     }

--- a/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
@@ -96,13 +96,15 @@ final class HomeViewController: UIViewController {
     }
     
     private func setMenuUI() {
-        let postRequestAction = UIAction(title: "대여 요청하기") { _ in
+        let presentPostRequestVC = UIAction(title: "대여 요청하기") { _ in
             // TODO: 요청 게시글 화면 이동
         }
-        let postRentAction = UIAction(title: "대여 등록하기") { _ in
-            // TODO: 등록 게시글 화면 이동
+        let presentPostRentVC = UIAction(title: "대여 등록하기") { _ in
+            let postRentVC = PostingRentViewController()
+            postRentVC.modalPresentationStyle = .fullScreen
+            self.present(postRentVC, animated: true)
         }
-        menuView.setMenuActions([postRequestAction, postRentAction])
+        menuView.setMenuActions([presentPostRequestVC, presentPostRentVC])
     }
     
     @objc func search() {


### PR DESCRIPTION
## 이슈
- #70 

## 체크리스트
- [x] UIAction 네이밍 수정
- [x] `presentPostRentVC` 구현

## 고민한 내용
- 게시글 등록은 홈 화면(게시글 목록)의 흐름에 속하지 않는다 생각했기 때문에 `push`가 아닌 `present`를 했습니다.
- `modalPresentationStyle`을 `fullScreen`으로 지정한 이유는 스크롤을 하다 모달 뷰가 내려져 자칫 작성한 내용이 다 날아가는 불편함이 생길 가능성이 있기 때문입니다.

## 스크린샷
https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/50a93b2a-1069-4af0-a543-3418b4d1ad97