### PR TITLE
[iOS/#82] 채팅방 화면 UI 구현 및 오토레이아웃 적용

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		8FD52A452B09D1A6005EE367 /* ChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD52A442B09D1A6005EE367 /* ChatViewController.swift */; };
 		8FD52A482B09D1AD005EE367 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD52A472B09D1AD005EE367 /* MyPageViewController.swift */; };
 		8FD52A4B2B0B0A2F005EE367 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD52A4A2B0B0A2F005EE367 /* SearchViewController.swift */; };
+		8FD52A512B0B51AF005EE367 /* ChatRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD52A502B0B51AF005EE367 /* ChatRoomViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		8FD52A442B09D1A6005EE367 /* ChatViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatViewController.swift; sourceTree = "<group>"; };
 		8FD52A472B09D1AD005EE367 /* MyPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		8FD52A4A2B0B0A2F005EE367 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		8FD52A502B0B51AF005EE367 /* ChatRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -184,6 +186,7 @@
 		8FBE3AED2B03549300660530 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				8FD52A4F2B0B51A2005EE367 /* ChatRoom */,
 				8FD52A492B0B0A20005EE367 /* Search */,
 				8FD52A462B09D1AD005EE367 /* MyPage */,
 				8FD52A432B09D1A6005EE367 /* Chat */,
@@ -288,6 +291,14 @@
 				8FD52A4A2B0B0A2F005EE367 /* SearchViewController.swift */,
 			);
 			path = Search;
+			sourceTree = "<group>";
+		};
+		8FD52A4F2B0B51A2005EE367 /* ChatRoom */ = {
+			isa = PBXGroup;
+			children = (
+				8FD52A502B0B51AF005EE367 /* ChatRoomViewController.swift */,
+			);
+			path = ChatRoom;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -427,6 +438,7 @@
 				4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */,
 				8FD52A452B09D1A6005EE367 /* ChatViewController.swift in Sources */,
 				8FBE3B122B04CF6300660530 /* UILabel+SetTitle.swift in Sources */,
+				8FD52A512B0B51AF005EE367 /* ChatRoomViewController.swift in Sources */,
 				8FBE3B0A2B0478D400660530 /* HomeCollectionViewCell.swift in Sources */,
 				440FCC2D2B04EB940011B637 /* Constants.swift in Sources */,
 				59D4DBE22B068C6400BBA2D5 /* UIView+Layer.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		59E0C6052AFBA3FE0073D494 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59E0C6042AFBA3FE0073D494 /* Assets.xcassets */; };
 		59E196C92B045F4900BF7C5A /* PostingRentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E196C82B045F4900BF7C5A /* PostingRentViewController.swift */; };
 		8F628D192B0349FE0013042E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 8F628D182B0349FE0013042E /* .swiftlint.yml */; };
+		8F95CF902B0B97F90024631F /* PostSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F95CF8F2B0B97F90024631F /* PostSummaryView.swift */; };
 		8FBE3B0A2B0478D400660530 /* HomeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B092B0478D400660530 /* HomeCollectionViewCell.swift */; };
 		8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B0B2B048B1300660530 /* HomeViewController.swift */; };
 		8FBE3B122B04CF6300660530 /* UILabel+SetTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B112B04CF6300660530 /* UILabel+SetTitle.swift */; };
@@ -60,6 +61,7 @@
 		59E0C6092AFBA3FE0073D494 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		59E196C82B045F4900BF7C5A /* PostingRentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingRentViewController.swift; sourceTree = "<group>"; };
 		8F628D182B0349FE0013042E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		8F95CF8F2B0B97F90024631F /* PostSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummaryView.swift; sourceTree = "<group>"; };
 		8FBE3B092B0478D400660530 /* HomeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCollectionViewCell.swift; sourceTree = "<group>"; };
 		8FBE3B0B2B048B1300660530 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		8FBE3B112B04CF6300660530 /* UILabel+SetTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+SetTitle.swift"; sourceTree = "<group>"; };
@@ -174,6 +176,14 @@
 			path = PostingRent;
 			sourceTree = "<group>";
 		};
+		8F95CF8E2B0B97BA0024631F /* Commons */ = {
+			isa = PBXGroup;
+			children = (
+				8F95CF8F2B0B97F90024631F /* PostSummaryView.swift */,
+			);
+			path = Commons;
+			sourceTree = "<group>";
+		};
 		8FBE3AEC2B03547E00660530 /* Application */ = {
 			isa = PBXGroup;
 			children = (
@@ -186,6 +196,7 @@
 		8FBE3AED2B03549300660530 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				8F95CF8E2B0B97BA0024631F /* Commons */,
 				8FD52A4F2B0B51A2005EE367 /* ChatRoom */,
 				8FD52A492B0B0A20005EE367 /* Search */,
 				8FD52A462B09D1AD005EE367 /* MyPage */,
@@ -445,6 +456,7 @@
 				8FBE3B142B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift in Sources */,
 				59E0C5FC2AFBA3FC0073D494 /* AppDelegate.swift in Sources */,
 				59D4DBDE2B06889300BBA2D5 /* TimePickerView.swift in Sources */,
+				8F95CF902B0B97F90024631F /* PostSummaryView.swift in Sources */,
 				8FD52A482B09D1AD005EE367 /* MyPageViewController.swift in Sources */,
 				59E196C92B045F4900BF7C5A /* PostingRentViewController.swift in Sources */,
 				8FD52A4B2B0B0A2F005EE367 /* SearchViewController.swift in Sources */,

--- a/iOS/Village/Village/Common/Constants.swift
+++ b/iOS/Village/Village/Common/Constants.swift
@@ -19,5 +19,7 @@ enum ImageSystemName: String {
     case person = "person"
     case personFill = "person.fill"
     case arrowLeft = "arrow.left"
+    case ellipsis
+    case paperplane
     
 }

--- a/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class ChatRoomViewController: UIViewController {
     
-    let chatStackView: UIStackView = {
+    private let chatStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
@@ -17,7 +17,7 @@ final class ChatRoomViewController: UIViewController {
         return stackView
     }()
     
-    let chatMoreButton: UIButton = {
+    private let chatMoreButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setImage(UIImage(systemName: ImageSystemName.plus.rawValue), for: .normal)
@@ -25,7 +25,7 @@ final class ChatRoomViewController: UIViewController {
         return button
     }()
     
-    let chatTextField: UITextField = {
+    private let chatTextField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.placeholder = "메시지를 입력해주세요."
@@ -35,7 +35,7 @@ final class ChatRoomViewController: UIViewController {
         return textField
     }()
     
-    let chatSendButton: UIButton = {
+    private let chatSendButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setImage(UIImage(systemName: ImageSystemName.paperplane.rawValue), for: .normal)
@@ -43,7 +43,7 @@ final class ChatRoomViewController: UIViewController {
         return button
     }()
     
-    let postSummaryView = PostSummaryView()
+    private let postSummaryView = PostSummaryView()
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
@@ -9,50 +9,6 @@ import UIKit
 
 class ChatRoomViewController: UIViewController {
     
-    let postView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        
-        return view
-    }()
-    
-    let postImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.image = UIImage(systemName: ImageSystemName.photo.rawValue)
-        imageView.contentMode = .scaleAspectFit
-        imageView.backgroundColor = .primary100
-        imageView.layer.cornerRadius = 16
-        
-        return imageView
-    }()
-    
-    let postTitleLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "닌텐도 스위치"
-        label.font = .systemFont(ofSize: 16, weight: .bold)
-        
-        return label
-    }()
-    
-    let postPriceLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "10000원"
-        label.font = .systemFont(ofSize: 14, weight: .bold)
-        
-        return label
-    }()
-    
-    let postAccessoryView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.image = UIImage(systemName: ImageSystemName.chevronRight.rawValue)
-        
-        return imageView
-    }()
-    
     let chatStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -86,6 +42,8 @@ class ChatRoomViewController: UIViewController {
         
         return button
     }()
+    
+    let postSummaryView = PostSummaryView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -97,12 +55,7 @@ class ChatRoomViewController: UIViewController {
     }
     
     private func setUI() {
-        
-        postView.addSubview(postImageView)
-        postView.addSubview(postTitleLabel)
-        postView.addSubview(postPriceLabel)
-        postView.addSubview(postAccessoryView)
-        view.addSubview(postView)
+        view.addSubview(postSummaryView)
         
         chatTextField.delegate = self
         
@@ -115,35 +68,6 @@ class ChatRoomViewController: UIViewController {
     }
     
     private func configureConstraints() {
-        
-        NSLayoutConstraint.activate([
-            postView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            postView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            postView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            postView.heightAnchor.constraint(equalToConstant: 100)
-        ])
-        
-        NSLayoutConstraint.activate([
-            postImageView.topAnchor.constraint(equalTo: postView.topAnchor, constant: 10),
-            postImageView.leadingAnchor.constraint(equalTo: postView.leadingAnchor, constant: 10),
-            postImageView.widthAnchor.constraint(equalToConstant: 80),
-            postImageView.heightAnchor.constraint(equalToConstant: 80)
-        ])
-        
-        NSLayoutConstraint.activate([
-            postTitleLabel.topAnchor.constraint(equalTo: postView.topAnchor, constant: 25),
-            postTitleLabel.leadingAnchor.constraint(equalTo: postImageView.trailingAnchor, constant: 20)
-        ])
-        
-        NSLayoutConstraint.activate([
-            postPriceLabel.topAnchor.constraint(equalTo: postTitleLabel.bottomAnchor, constant: 10),
-            postPriceLabel.leadingAnchor.constraint(equalTo: postImageView.trailingAnchor, constant: 20)
-        ])
-        
-        NSLayoutConstraint.activate([
-            postAccessoryView.topAnchor.constraint(equalTo: postView.topAnchor, constant: 39),
-            postAccessoryView.trailingAnchor.constraint(equalTo: postView.trailingAnchor, constant: -16)
-        ])
         
         NSLayoutConstraint.activate([
             chatStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
@@ -1,0 +1,118 @@
+//
+//  ChatRoomViewController.swift
+//  Village
+//
+//  Created by 박동재 on 2023/11/20.
+//
+
+import UIKit
+
+class ChatRoomViewController: UIViewController {
+    
+    let chatStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        
+        return stackView
+    }()
+    
+    let chatMoreButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: ImageSystemName.plus.rawValue), for: .normal)
+        
+        return button
+    }()
+    
+    let chatTextField: UITextField = {
+        let textField = UITextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.placeholder = "메시지를 입력해주세요."
+        textField.borderStyle = .roundedRect
+        textField.backgroundColor = .grey100
+        
+        return textField
+    }()
+    
+    let chatSendButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: ImageSystemName.paperplane.rawValue), for: .normal)
+        
+        return button
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setNavigationUI()
+        setUI()
+        
+        view.backgroundColor = .systemBackground
+    }
+    
+    private func setUI() {
+        
+        chatTextField.delegate = self
+        
+        chatStackView.addArrangedSubview(chatMoreButton)
+        chatStackView.addArrangedSubview(chatTextField)
+        chatStackView.addArrangedSubview(chatSendButton)
+        view.addSubview(chatStackView)
+        
+        configureConstraints()
+    }
+    
+    private func configureConstraints() {
+        NSLayoutConstraint.activate([
+            chatStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            chatStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            chatStackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -20)
+        ])
+        
+        NSLayoutConstraint.activate([
+            chatMoreButton.widthAnchor.constraint(equalToConstant: 40)
+        ])
+        
+        NSLayoutConstraint.activate([
+            chatTextField.heightAnchor.constraint(equalToConstant: 40)
+        ])
+        
+        NSLayoutConstraint.activate([
+            chatSendButton.widthAnchor.constraint(equalToConstant: 40)
+        ])
+        
+    }
+    
+    private func setNavigationUI() {
+        let arrowLeft = self.navigationItem.makeSFSymbolButton(
+            self, action: #selector(backButtonTapped), symbolName: .arrowLeft
+        )
+        let ellipsis = self.navigationItem.makeSFSymbolButton(
+            self, action: #selector(ellipsisTapped), symbolName: .ellipsis
+        )
+        
+        navigationItem.title = "다른 사용자"
+        navigationItem.leftBarButtonItem = arrowLeft
+        navigationItem.rightBarButtonItem = ellipsis
+    }
+    
+    @objc private func backButtonTapped() {
+        self.dismiss(animated: true)
+    }
+    
+    @objc private func ellipsisTapped() {
+        // TODO: 더보기 버튼 클릭 액션
+    }
+    
+}
+
+extension ChatRoomViewController: UITextFieldDelegate {
+    
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class ChatRoomViewController: UIViewController {
+final class ChatRoomViewController: UIViewController {
     
     let chatStackView: UIStackView = {
         let stackView = UIStackView()

--- a/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ChatRoomViewController.swift
@@ -9,6 +9,50 @@ import UIKit
 
 class ChatRoomViewController: UIViewController {
     
+    let postView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    let postImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = UIImage(systemName: ImageSystemName.photo.rawValue)
+        imageView.contentMode = .scaleAspectFit
+        imageView.backgroundColor = .primary100
+        imageView.layer.cornerRadius = 16
+        
+        return imageView
+    }()
+    
+    let postTitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "닌텐도 스위치"
+        label.font = .systemFont(ofSize: 16, weight: .bold)
+        
+        return label
+    }()
+    
+    let postPriceLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "10000원"
+        label.font = .systemFont(ofSize: 14, weight: .bold)
+        
+        return label
+    }()
+    
+    let postAccessoryView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = UIImage(systemName: ImageSystemName.chevronRight.rawValue)
+        
+        return imageView
+    }()
+    
     let chatStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -54,6 +98,12 @@ class ChatRoomViewController: UIViewController {
     
     private func setUI() {
         
+        postView.addSubview(postImageView)
+        postView.addSubview(postTitleLabel)
+        postView.addSubview(postPriceLabel)
+        postView.addSubview(postAccessoryView)
+        view.addSubview(postView)
+        
         chatTextField.delegate = self
         
         chatStackView.addArrangedSubview(chatMoreButton)
@@ -65,6 +115,36 @@ class ChatRoomViewController: UIViewController {
     }
     
     private func configureConstraints() {
+        
+        NSLayoutConstraint.activate([
+            postView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            postView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            postView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            postView.heightAnchor.constraint(equalToConstant: 100)
+        ])
+        
+        NSLayoutConstraint.activate([
+            postImageView.topAnchor.constraint(equalTo: postView.topAnchor, constant: 10),
+            postImageView.leadingAnchor.constraint(equalTo: postView.leadingAnchor, constant: 10),
+            postImageView.widthAnchor.constraint(equalToConstant: 80),
+            postImageView.heightAnchor.constraint(equalToConstant: 80)
+        ])
+        
+        NSLayoutConstraint.activate([
+            postTitleLabel.topAnchor.constraint(equalTo: postView.topAnchor, constant: 25),
+            postTitleLabel.leadingAnchor.constraint(equalTo: postImageView.trailingAnchor, constant: 20)
+        ])
+        
+        NSLayoutConstraint.activate([
+            postPriceLabel.topAnchor.constraint(equalTo: postTitleLabel.bottomAnchor, constant: 10),
+            postPriceLabel.leadingAnchor.constraint(equalTo: postImageView.trailingAnchor, constant: 20)
+        ])
+        
+        NSLayoutConstraint.activate([
+            postAccessoryView.topAnchor.constraint(equalTo: postView.topAnchor, constant: 39),
+            postAccessoryView.trailingAnchor.constraint(equalTo: postView.trailingAnchor, constant: -16)
+        ])
+        
         NSLayoutConstraint.activate([
             chatStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             chatStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),

--- a/iOS/Village/Village/Presentation/Commons/PostSummaryView.swift
+++ b/iOS/Village/Village/Presentation/Commons/PostSummaryView.swift
@@ -1,0 +1,103 @@
+//
+//  PostSummaryView.swift
+//  Village
+//
+//  Created by 박동재 on 2023/11/20.
+//
+
+import UIKit
+
+final class PostSummaryView: UIView {
+    
+    let postView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    let postImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        imageView.layer.cornerRadius = 16
+        
+        return imageView
+    }()
+    
+    let postTitleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 16, weight: .bold)
+        
+        return label
+    }()
+    
+    let postPriceLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 14, weight: .bold)
+        
+        return label
+    }()
+    
+    let postAccessoryView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = UIImage(systemName: ImageSystemName.chevronRight.rawValue)
+        
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setUI()
+    }
+    
+    private func setUI() {
+        postView.addSubview(postImageView)
+        postView.addSubview(postTitleLabel)
+        postView.addSubview(postPriceLabel)
+        postView.addSubview(postAccessoryView)
+        self.addSubview(postView)
+        
+        configureConstraints()
+    }
+    
+    private func configureConstraints() {
+        
+        NSLayoutConstraint.activate([
+            postView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
+            postView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            postView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            postView.heightAnchor.constraint(equalToConstant: 100)
+        ])
+        
+        NSLayoutConstraint.activate([
+            postImageView.topAnchor.constraint(equalTo: postView.topAnchor, constant: 10),
+            postImageView.leadingAnchor.constraint(equalTo: postView.leadingAnchor, constant: 10),
+            postImageView.widthAnchor.constraint(equalToConstant: 80),
+            postImageView.heightAnchor.constraint(equalToConstant: 80)
+        ])
+        
+        NSLayoutConstraint.activate([
+            postTitleLabel.topAnchor.constraint(equalTo: postView.topAnchor, constant: 25),
+            postTitleLabel.leadingAnchor.constraint(equalTo: postImageView.trailingAnchor, constant: 20)
+        ])
+        
+        NSLayoutConstraint.activate([
+            postPriceLabel.topAnchor.constraint(equalTo: postTitleLabel.bottomAnchor, constant: 10),
+            postPriceLabel.leadingAnchor.constraint(equalTo: postImageView.trailingAnchor, constant: 20)
+        ])
+        
+        NSLayoutConstraint.activate([
+            postAccessoryView.topAnchor.constraint(equalTo: postView.topAnchor, constant: 39),
+            postAccessoryView.trailingAnchor.constraint(equalTo: postView.trailingAnchor, constant: -16)
+        ])
+    }
+}

--- a/iOS/Village/Village/Presentation/Home/View/HomeCollectionViewCell.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeCollectionViewCell.swift
@@ -21,83 +21,24 @@ final class HomeCollectionViewCell: UICollectionViewCell {
         setUI()
     }
     
-    private let postImageView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.contentMode = .scaleAspectFit
-        imageView.layer.cornerRadius = 16
-        
-        return imageView
-    }()
-    
-    private let titleLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .systemFont(ofSize: 16, weight: .bold)
-        
-        return label
-    }()
-    
-    private let priceLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = .systemFont(ofSize: 14, weight: .bold)
-        
-        return label
-    }()
-    
-    private let accessoryView: UIImageView = {
-        let imageView = UIImageView()
-        imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.image = UIImage(systemName: ImageSystemName.chevronRight.rawValue)
-        
-        return imageView
-    }()
+    let postSummaryView = PostSummaryView()
     
     private func setUI() {
-        self.addSubview(postImageView)
-        self.addSubview(titleLabel)
-        self.addSubview(priceLabel)
-        self.addSubview(accessoryView)
-        configureConstraints()
-    }
-    
-    private func configureConstraints() {
-        NSLayoutConstraint.activate([
-            postImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            postImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 10),
-            postImageView.widthAnchor.constraint(equalToConstant: 80),
-            postImageView.heightAnchor.constraint(equalToConstant: 80)
-        ])
-        
-        NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: self.topAnchor, constant: 25),
-            titleLabel.leadingAnchor.constraint(equalTo: postImageView.trailingAnchor, constant: 20)
-        ])
-        
-        NSLayoutConstraint.activate([
-            priceLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 10),
-            priceLabel.leadingAnchor.constraint(equalTo: postImageView.trailingAnchor, constant: 20)
-        ])
-        
-        NSLayoutConstraint.activate([
-            accessoryView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            accessoryView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -16)
-        ])
+        self.addSubview(postSummaryView)
     }
     
     func configureData(post: Post) {
-        titleLabel.text = post.title
+        postSummaryView.postTitleLabel.text = post.title
         let price = post.price.map(String.init) ?? ""
-        priceLabel.text = price != "" ? "\(price)원" : ""
+        postSummaryView.postPriceLabel.text = price != "" ? "\(price)원" : ""
     }
     
     func configureImage(image: UIImage?) {
         if image != nil {
-            postImageView.image = image
+            postSummaryView.postImageView.image = image
         } else {
-            postImageView.image = UIImage(systemName: ImageSystemName.photo.rawValue)
-            postImageView.backgroundColor = .primary100
+            postSummaryView.postImageView.image = UIImage(systemName: ImageSystemName.photo.rawValue)
+            postSummaryView.postImageView.backgroundColor = .primary100
         }
     }
 }


### PR DESCRIPTION
## 이슈
- #82

## 체크리스트
- [x] 채팅방 화면 UI 구현
- [x] 재사용가능한 PostSummaryView 구현

## 고민한 내용
- 홈 화면에서 사용한 뷰 구성이 동일하여 재사용하고 싶었음
- 공통 폴더를 하나 만들어서 재사용가능한 뷰로 구현

## 스크린샷
<img src=https://github.com/boostcampwm2023/iOS05-Village/assets/59719500/a725be7c-9b5a-42cf-a35e-ba5115850c81 width=300 />

