### PR TITLE
[BE/#107] Get /user/{id} API 구현

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -10,6 +10,7 @@ import { winstonOptions, dailyOption } from './config/winston.config';
 import { MysqlConfigProvider } from './config/mysql.config';
 import { PostModule } from './post/post.module';
 import { APP_PIPE } from '@nestjs/core';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { APP_PIPE } from '@nestjs/core';
       useClass: MysqlConfigProvider,
     }),
     PostModule,
+    UsersModule,
   ],
   controllers: [AppController],
   providers: [

--- a/BE/src/users/createUser.dto.ts
+++ b/BE/src/users/createUser.dto.ts
@@ -1,0 +1,12 @@
+import { IsString } from 'class-validator';
+
+export class CreateUserDto {
+  @IsString()
+  nickname: string;
+
+  @IsString()
+  social_email: string;
+
+  @IsString()
+  OAuth_domain: string;
+}

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -1,0 +1,40 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  UseInterceptors,
+  UploadedFiles,
+  ValidationPipe,
+} from '@nestjs/common';
+import { UsersService } from './users.service';
+import { CreateUserDto } from './createUser.dto';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { MultiPartBody } from 'src/utils/multiPartBody.decorator';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Post()
+  @UseInterceptors(FileInterceptor('profileImage'))
+  async usersCreate(
+    @UploadedFiles() files: Express.Multer.File,
+    @MultiPartBody(
+      'profile',
+      new ValidationPipe({ validateCustomDecorators: true }),
+    )
+    createUserDto: CreateUserDto,
+  ) {
+    const user = await this.usersService.createUser(createUserDto);
+    return user;
+  }
+
+  @Delete(':id')
+  usersRemove(@Param('id') id: string) {
+    return this.usersService.removeUser(+id);
+  }
+}

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -9,6 +9,7 @@ import {
   UseInterceptors,
   UploadedFiles,
   ValidationPipe,
+  HttpException,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './createUser.dto';
@@ -18,6 +19,16 @@ import { MultiPartBody } from 'src/utils/multiPartBody.decorator';
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
+
+  @Get(':id')
+  async usersDetails(@Param('id') userId) {
+    const user = await this.usersService.findUserById(userId);
+    if (user === null) {
+      throw new HttpException('유저가 존재하지않습니다.', 404);
+    } else {
+      return user;
+    }
+  }
 
   @Post()
   @UseInterceptors(FileInterceptor('profileImage'))

--- a/BE/src/users/users.module.ts
+++ b/BE/src/users/users.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+
+@Module({
+  controllers: [UsersController],
+  providers: [UsersService],
+})
+export class UsersModule {}

--- a/BE/src/users/users.module.ts
+++ b/BE/src/users/users.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { PostEntity } from '../entities/post.entity';
+import { UserEntity } from '../entities/user.entity';
+import { PostImageEntity } from '../entities/postImage.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([UserEntity])],
   controllers: [UsersController],
   providers: [UsersService],
 })

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -1,8 +1,25 @@
 import { Injectable } from '@nestjs/common';
 import { CreateUserDto } from './createUser.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserEntity } from '../entities/user.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class UsersService {
+  constructor(
+    @InjectRepository(UserEntity)
+    private userRepository: Repository<UserEntity>,
+  ) {}
+  async findUserById(userId: string) {
+    const user: UserEntity = await this.userRepository.findOne({
+      where: { user_hash: userId, status: true },
+    });
+    if (user) {
+      return { nickname: user.nickname, profile_img: user.profile_img };
+    } else {
+      return null;
+    }
+  }
   createUser(createUserDto: CreateUserDto) {
     return 'This action adds a new user';
   }

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { CreateUserDto } from './createUser.dto';
+
+@Injectable()
+export class UsersService {
+  createUser(createUserDto: CreateUserDto) {
+    return 'This action adds a new user';
+  }
+
+  removeUser(id: number) {
+    return `This action removes a #${id} user`;
+  }
+}


### PR DESCRIPTION
## 이슈
- #107

## 체크리스트
- id를 기반으로 유저 정보를 조회기능 구현
- 삭제 처리된 유저는 조회되지 않도록 구현

## 고민한 내용
좀 더 응답을 깔끔하게 내릴 수 있는 방법이 없을지 고민 하고 있었다. 엔티티와 응답 json은 구조가 매우 비슷해지 는데 현재로서는 응답 객체를 만들기위해 엔티티에서 일일이 값을 뽑아서 만들고 있다.그래서 어떻게 더 깔끔한 방법은 없을까 찾아봤지만 아직 까지는 찾지 못했다.

## 스크린샷
