### PR TITLE
[iOS/#110] 네트워크 레이어 테스트

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		59DC1B1F2B0C6AEC004C8C1A /* PostingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DC1B1E2B0C6AEC004C8C1A /* PostingViewModel.swift */; };
 		59E0C5FC2AFBA3FC0073D494 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0C5FB2AFBA3FC0073D494 /* AppDelegate.swift */; };
 		59E0C6052AFBA3FE0073D494 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59E0C6042AFBA3FE0073D494 /* Assets.xcassets */; };
+		8F1B53322B0DE0D8006D8982 /* APIEndPoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1B53312B0DE0D8006D8982 /* APIEndPoints.swift */; };
+		8F1B53362B0E0396006D8982 /* PostRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1B53352B0E0396006D8982 /* PostRequestDTO.swift */; };
+		8F1B53382B0E03AE006D8982 /* PostResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1B53372B0E03AE006D8982 /* PostResponseDTO.swift */; };
 		8F628D192B0349FE0013042E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 8F628D182B0349FE0013042E /* .swiftlint.yml */; };
 		8F95CF902B0B97F90024631F /* PostSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F95CF8F2B0B97F90024631F /* PostSummaryView.swift */; };
 		8F95CF922B0C57460024631F /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F95CF912B0C57460024631F /* NetworkError.swift */; };
@@ -76,6 +79,9 @@
 		59E0C6042AFBA3FE0073D494 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		59E0C6092AFBA3FE0073D494 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		59E196C82B045F4900BF7C5A /* PostingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingViewController.swift; sourceTree = "<group>"; };
+		8F1B53312B0DE0D8006D8982 /* APIEndPoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndPoints.swift; sourceTree = "<group>"; };
+		8F1B53352B0E0396006D8982 /* PostRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRequestDTO.swift; sourceTree = "<group>"; };
+		8F1B53372B0E03AE006D8982 /* PostResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostResponseDTO.swift; sourceTree = "<group>"; };
 		8F628D182B0349FE0013042E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		8F95CF8F2B0B97F90024631F /* PostSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummaryView.swift; sourceTree = "<group>"; };
 		8F95CF912B0C57460024631F /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
@@ -135,6 +141,7 @@
 		5975E98D2B03591E007CEF13 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				8F1B53302B0DE0B3006D8982 /* Network */,
 				59AA12952B036BFC00AFC766 /* Dummy */,
 			);
 			path = Data;
@@ -213,6 +220,7 @@
 		59E0C5FA2AFBA3FC0073D494 /* Village */ = {
 			isa = PBXGroup;
 			children = (
+				8F1B53332B0E037C006D8982 /* Domain */,
 				8FC7FE762B06767600B91D3B /* Network */,
 				8FBE3AEC2B03547E00660530 /* Application */,
 				440FCC2B2B04EB830011B637 /* Common */,
@@ -231,6 +239,31 @@
 				59BD5DD02B0C785900FEB80F /* View */,
 			);
 			path = Posting;
+			sourceTree = "<group>";
+		};
+		8F1B53302B0DE0B3006D8982 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				8F1B53312B0DE0D8006D8982 /* APIEndPoints.swift */,
+			);
+			path = Network;
+			sourceTree = "<group>";
+		};
+		8F1B53332B0E037C006D8982 /* Domain */ = {
+			isa = PBXGroup;
+			children = (
+				8F1B53342B0E0384006D8982 /* Network */,
+			);
+			path = Domain;
+			sourceTree = "<group>";
+		};
+		8F1B53342B0E0384006D8982 /* Network */ = {
+			isa = PBXGroup;
+			children = (
+				8F1B53352B0E0396006D8982 /* PostRequestDTO.swift */,
+				8F1B53372B0E03AE006D8982 /* PostResponseDTO.swift */,
+			);
+			path = Network;
 			sourceTree = "<group>";
 		};
 		8F95CF8E2B0B97BA0024631F /* Commons */ = {
@@ -537,11 +570,14 @@
 				59BD5DCE2B0C775D00FEB80F /* SceneDelegate.swift in Sources */,
 				59BD5DCD2B0C775200FEB80F /* FloatingButton.swift in Sources */,
 				59BD5DCC2B0C772200FEB80F /* PostingViewController.swift in Sources */,
+				8F1B53322B0DE0D8006D8982 /* APIEndPoints.swift in Sources */,
 				59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */,
 				8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */,
+				8F1B53382B0E03AE006D8982 /* PostResponseDTO.swift in Sources */,
 				4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */,
 				8F95CF982B0C7B270024631F /* Reponsable.swift in Sources */,
 				8F95CF922B0C57460024631F /* NetworkError.swift in Sources */,
+				8F1B53362B0E0396006D8982 /* PostRequestDTO.swift in Sources */,
 				8FD52A452B09D1A6005EE367 /* ChatViewController.swift in Sources */,
 				8FBE3B122B04CF6300660530 /* UILabel+SetTitle.swift in Sources */,
 				8FD52A512B0B51AF005EE367 /* ChatRoomViewController.swift in Sources */,
@@ -560,8 +596,6 @@
 				8FD52A482B09D1AD005EE367 /* MyPageViewController.swift in Sources */,
 				8FD52A4B2B0B0A2F005EE367 /* SearchViewController.swift in Sources */,
 				8F95CF962B0C66910024631F /* Requestable.swift in Sources */,
-				59E0C5FE2AFBA3FC0073D494 /* SceneDelegate.swift in Sources */,
-				44425A642B038AEA00AAD64A /* FloatingButton.swift in Sources */,
 				8FC7FE782B06768C00B91D3B /* NetworkService.swift in Sources */,
 				8FC7FE742B05CE9A00B91D3B /* PostListItemViewModel.swift in Sources */,
 				8F95CF9C2B0C81640024631F /* Provider.swift in Sources */,

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -1,0 +1,33 @@
+//
+//  APIEndPoints.swift
+//  Village
+//
+//  Created by 박동재 on 2023/11/22.
+//
+
+import Foundation
+
+struct APIEndPoints {
+    
+    static func getPosts(with postResponse: PostRequestDTO) -> EndPoint<[PostResponseDTO]> {
+        return EndPoint(
+            baseURL: "http://118.67.130.107:3000/",
+            path: "posts",
+            method: .GET,
+            queryParameters: postResponse
+        )
+    }
+    
+    static func getData(with url: String) -> EndPoint<Data> {
+        return EndPoint(baseURL: url)
+    }
+    
+    static func getOnban(with request: TestRequestDTO) -> EndPoint<Onban> {
+        return EndPoint(
+            baseURL: "https://api.codesquad.kr/onban/",
+            path: "main",
+            method: .GET,
+            queryParameters: request
+        )
+    }
+}

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -22,12 +22,4 @@ struct APIEndPoints {
         return EndPoint(baseURL: url)
     }
     
-    static func getOnban(with request: TestRequestDTO) -> EndPoint<Onban> {
-        return EndPoint(
-            baseURL: "https://api.codesquad.kr/onban/",
-            path: "main",
-            method: .GET,
-            queryParameters: request
-        )
-    }
 }

--- a/iOS/Village/Village/Domain/Network/PostRequestDTO.swift
+++ b/iOS/Village/Village/Domain/Network/PostRequestDTO.swift
@@ -1,0 +1,18 @@
+//
+//  PostRequestDTO.swift
+//  Village
+//
+//  Created by 박동재 on 2023/11/22.
+//
+
+import Foundation
+
+struct PostRequestDTO: Codable {
+    
+    let page: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case page
+    }
+    
+}

--- a/iOS/Village/Village/Domain/Network/PostResponseDTO.swift
+++ b/iOS/Village/Village/Domain/Network/PostResponseDTO.swift
@@ -1,0 +1,33 @@
+//
+//  PostResponseDTO.swift
+//  Village
+//
+//  Created by 박동재 on 2023/11/22.
+//
+
+import Foundation
+
+struct PostResponseDTO: Hashable, Codable {
+    
+    let title: String
+    let price: Int?
+    let contents: String
+    let postId: Int
+    let userId: Int
+    let isRequest: Int
+    let images: [String]
+    let startDate: String
+    let endDate: String
+    
+    enum CodingKeys: String, CodingKey {
+        case title
+        case price
+        case contents
+        case postId = "post_id"
+        case userId = "user_id"
+        case isRequest = "is_request"
+        case images
+        case startDate = "start_date"
+        case endDate = "end_date"
+    }
+}

--- a/iOS/Village/Village/Network/EndPoint/EndPoint.swift
+++ b/iOS/Village/Village/Network/EndPoint/EndPoint.swift
@@ -25,8 +25,7 @@ final class EndPoint<R>: RequestResponsable {
          method: HTTPMethod = .GET,
          queryParameters: Encodable? = nil,
          bodyParameters: Encodable? = nil,
-         headers: [String: String]? = [:],
-         sampleData: Data? = nil) {
+         headers: [String: String]? = [:]) {
         self.baseURL = baseURL
         self.path = path
         self.method = method

--- a/iOS/Village/Village/Network/Provider/Provider.swift
+++ b/iOS/Village/Village/Network/Provider/Provider.swift
@@ -16,6 +16,8 @@ protocol ProviderProtocol {
 
 final class Provider: ProviderProtocol {
     
+    static let shared = Provider()
+    
     let session: URLSession
     
     init(session: URLSession = URLSession.shared) {

--- a/iOS/Village/Village/Presentation/DetailPost/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/DetailPost/PostDetailViewController.swift
@@ -9,9 +9,9 @@ import UIKit
 
 class PostDetailViewController: UIViewController {
     
-    var postData: Post?
+    var postData: PostResponseDTO?
     
-    init(postData: Post? = nil) {
+    init(postData: PostResponseDTO? = nil) {
         self.postData = postData
         super.init(nibName: nil, bundle: nil)
     }

--- a/iOS/Village/Village/Presentation/Home/View/HomeCollectionViewCell.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeCollectionViewCell.swift
@@ -27,7 +27,7 @@ final class HomeCollectionViewCell: UICollectionViewCell {
         self.addSubview(postSummaryView)
     }
     
-    func configureData(post: Post) {
+    func configureData(post: PostResponseDTO) {
         postSummaryView.postTitleLabel.text = post.title
         let price = post.price.map(String.init) ?? ""
         postSummaryView.postPriceLabel.text = price != "" ? "\(price)원" : ""

--- a/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
@@ -10,7 +10,7 @@ import Combine
 
 final class HomeViewController: UIViewController {
     
-    typealias HomeDataSource = UICollectionViewDiffableDataSource<Section, Post>
+    typealias HomeDataSource = UICollectionViewDiffableDataSource<Section, PostResponseDTO>
     
     private var dataSource: HomeDataSource!
     private let reuseIdentifier = HomeCollectionViewCell.identifier
@@ -53,14 +53,12 @@ final class HomeViewController: UIViewController {
             .store(in: &cancellableBag)
         
         setupUI()
-        generateData()
     }
     
     private func setupUI() {
         setNavigationUI()
         setMenuUI()
         configureCollectionView()
-        configureDataSource()
         
         view.addSubview(floatingButton)
         view.addSubview(menuView)
@@ -68,18 +66,16 @@ final class HomeViewController: UIViewController {
     }
     
     private func setViewModel() {
-        guard let path = Bundle.main.path(forResource: "Post", ofType: "json") else { return }
-        
-        guard let jsonString = try? String(contentsOfFile: path) else { return }
-        do {
-            let decoder = JSONDecoder()
-            let data = jsonString.data(using: .utf8)
-            
-            guard let data = data else { return }
-            let posts = try decoder.decode(PostResponse.self, from: data)
-            viewModel.updatePosts(updatePosts: posts.body)
-        } catch {
-            return
+        let endpoint = APIEndPoints.getPosts(with: PostRequestDTO(page: 1))
+        Task {
+            do {
+                let data = try await Provider.shared.request(with: endpoint)
+                viewModel.updatePosts(data)
+                configureDataSource()
+                generateData()
+            } catch {
+                dump(error)
+            }
         }
     }
     
@@ -157,11 +153,12 @@ final class HomeViewController: UIViewController {
             cell.configureData(post: post)
             
             if let imageURL = post.images.first {
+                let endpoint = APIEndPoints.getData(with: imageURL)
                 Task {
                     do {
-                        let data = try await NetworkService.loadData(from: imageURL)
+                        let data = try await Provider.shared.request(from: endpoint.baseURL)
                         cell.configureImage(image: UIImage(data: data))
-                    } catch let error {
+                    } catch {
                         dump(error)
                     }
                 }
@@ -174,10 +171,10 @@ final class HomeViewController: UIViewController {
     }
     
     private func generateData() {
-        var snapshot = NSDiffableDataSourceSnapshot<Section, Post>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, PostResponseDTO>()
         snapshot.appendSections([.main])
         
-        snapshot.appendItems(viewModel.getPosts())
+        snapshot.appendItems(viewModel.getTest())
         dataSource.apply(snapshot, animatingDifferences: true)
     }
     

--- a/iOS/Village/Village/Presentation/Home/ViewModel/PostListItemViewModel.swift
+++ b/iOS/Village/Village/Presentation/Home/ViewModel/PostListItemViewModel.swift
@@ -36,17 +36,17 @@ struct Post: Hashable, Codable {
 }
 
 final class PostListItemViewModel {
-    private var posts: [Post] = []
+    private var posts: [PostResponseDTO] = []
     
-    func updatePosts(updatePosts: [Post]) {
+    func updatePosts(_ updatePosts: [PostResponseDTO]) {
         self.posts = updatePosts
     }
     
-    func getPosts() -> [Post] {
+    func getTest() -> [PostResponseDTO] {
         return posts
     }
     
-    func getPost(_ index: Int) -> Post {
+    func getPost(_ index: Int) -> PostResponseDTO {
         return posts[index]
     }
     

--- a/iOS/Village/Village/Resources/Info.plist
+++ b/iOS/Village/Village/Resources/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
## 이슈
- #110

## 체크리스트
- [x] 네트워크 레이어 테스트
- [x] DTO 생성
- [x] 네트워크 통신 후 뷰모델 변경

## 고민한 내용
### 구성한 네트워크 레이어를 이용해서 통신을 구현하는 과정에서의 고민
- 내가 작성한 코드가 맞는 방식인지 아닌지 심히 고민됨..
- 여러군데에서 Provider를 사용할 것이라고 생각해서 싱글톤으로 생성
- 홈화면에서는 네트워크 통신 후, 뷰모델을 업데이트 한 뒤 다음 함수를 호출하여 컬렉션 뷰를 업데이트하는 방식으로 구현
- 추후에 페이지네이션을 통한 로직도 구현해야겠다고 생각.
~~~swift
configureDataSource()
generateData()
~~~

## 스크린샷

![Simulator Screen Recording - iPhone 15 Pro - 2023-11-23 at 02 49 25](https://github.com/boostcampwm2023/iOS05-Village/assets/59719500/366d033b-ac65-467d-be91-2ac31817cd25)
