### PR TITLE
[BE/#119] PATCH /users/{id} API 구현

### DIFF
--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -92,7 +92,7 @@ export class PostService {
   async changeExceptImages(postId: number, updatePostDto: UpdatePostDto) {
     try {
       await this.postRepository.update({ id: postId }, updatePostDto);
-    } catch {
+    } catch (e) {
       throw new HttpException('서버 오류입니다.', 500);
     }
   }
@@ -115,7 +115,7 @@ export class PostService {
         await this.changeImages(postId, updatePostDto.images);
         return true;
       }
-    } catch {
+    } catch (e) {
       return null;
     }
   }

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -10,11 +10,14 @@ import {
   UploadedFiles,
   ValidationPipe,
   HttpException,
+  UploadedFile,
+  HttpCode,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { CreateUserDto } from './createUser.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { MultiPartBody } from 'src/utils/multiPartBody.decorator';
+import { UpdateUsersDto } from './usersUpdate.dto';
 
 @Controller('users')
 export class UsersController {
@@ -47,5 +50,15 @@ export class UsersController {
   @Delete(':id')
   usersRemove(@Param('id') id: string) {
     return this.usersService.removeUser(+id);
+  }
+
+  @Patch(':id')
+  @UseInterceptors(FileInterceptor('image'))
+  async usersModify(
+    @Param('id') userId: string,
+    @MultiPartBody('profile') body: UpdateUsersDto,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    await this.usersService.updateUserById(userId, body, file);
   }
 }

--- a/BE/src/users/users.module.ts
+++ b/BE/src/users/users.module.ts
@@ -4,7 +4,6 @@ import { UsersController } from './users.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { S3Handler } from 'src/utils/S3Handler';
 import { UserEntity } from '../entities/user.entity';
-import { S3Handler } from '../utils/S3Handler';
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserEntity])],

--- a/BE/src/users/users.module.ts
+++ b/BE/src/users/users.module.ts
@@ -5,10 +5,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostEntity } from '../entities/post.entity';
 import { UserEntity } from '../entities/user.entity';
 import { PostImageEntity } from '../entities/postImage.entity';
+import { S3Handler } from '../utils/S3Handler';
 
 @Module({
   imports: [TypeOrmModule.forFeature([UserEntity])],
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [UsersService, S3Handler],
 })
 export class UsersModule {}

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -1,14 +1,18 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { CreateUserDto } from './createUser.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserEntity } from '../entities/user.entity';
 import { Repository } from 'typeorm';
+import { UpdatePostDto } from '../post/dto/postUpdate.dto';
+import { UpdateUsersDto } from './usersUpdate.dto';
+import { S3Handler } from '../utils/S3Handler';
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(UserEntity)
     private userRepository: Repository<UserEntity>,
+    private s3Handler: S3Handler,
   ) {}
   async findUserById(userId: string) {
     const user: UserEntity = await this.userRepository.findOne({
@@ -26,5 +30,57 @@ export class UsersService {
 
   removeUser(id: number) {
     return `This action removes a #${id} user`;
+  }
+
+  async updateUserById(
+    userId: string,
+    body: UpdateUsersDto,
+    file: Express.Multer.File,
+  ) {
+    const isDataExists = await this.userRepository.findOne({
+      where: { user_hash: userId },
+    });
+    const isChangingImage = file !== undefined;
+    const isChangingBody = body !== undefined;
+
+    if (!isDataExists) {
+      throw new HttpException('유저가 존재하지 않습니다.', 404);
+    } else if (!isChangingImage && isChangingBody) {
+      await this.changeExceptImages(userId, body);
+    } else if (!isChangingBody && !isChangingImage) {
+      throw new HttpException('수정 할 것이 없는데 요청을 보냈습니다.', 400);
+    } else if (!isChangingBody && isChangingImage) {
+      await this.changeImages(userId, file);
+    } else {
+      await this.changeExceptImages(userId, body);
+      await this.changeImages(userId, file);
+    }
+  }
+
+  async changeExceptImages(userId: string, body: UpdateUsersDto) {
+    try {
+      await this.userRepository.update({ user_hash: userId }, body);
+    } catch (e) {
+      throw new HttpException('서버 오류입니다. db', 500);
+    }
+  }
+
+  async changeImages(userId: string, file: Express.Multer.File) {
+    try {
+      if (file === null) {
+        await this.userRepository.update(
+          { user_hash: userId },
+          { profile_img: null },
+        );
+      } else {
+        const fileLocation = await this.s3Handler.uploadFile(file);
+        await this.userRepository.update(
+          { user_hash: userId },
+          { profile_img: fileLocation },
+        );
+      }
+    } catch (e) {
+      throw new HttpException('서버 오류입니다. ima', 500);
+    }
   }
 }

--- a/BE/src/users/usersUpdate.dto.ts
+++ b/BE/src/users/usersUpdate.dto.ts
@@ -1,0 +1,7 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateUsersDto {
+  @IsOptional() // 이 필드는 선택적으로 업데이트할 수 있도록 설정
+  @IsString()
+  nickname?: string;
+}

--- a/BE/src/users/usersUpdate.dto.ts
+++ b/BE/src/users/usersUpdate.dto.ts
@@ -1,7 +1,11 @@
-import { IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class UpdateUsersDto {
   @IsOptional() // 이 필드는 선택적으로 업데이트할 수 있도록 설정
   @IsString()
   nickname?: string;
+
+  @IsOptional() // 이 필드는 선택적으로 업데이트할 수 있도록 설정
+  @IsBoolean()
+  is_image_changed?: string;
 }

--- a/BE/src/utils/multiPartBody.decorator.ts
+++ b/BE/src/utils/multiPartBody.decorator.ts
@@ -4,7 +4,12 @@ export const MultiPartBody = createParamDecorator(
   (data: string, ctx: ExecutionContext) => {
     const request: Request = ctx.switchToHttp().getRequest();
     const body = request.body;
-
-    return data ? JSON.parse(body?.[data]) : body;
+    const parsedBody = body?.[data];
+    if (parsedBody === undefined) {
+      return undefined;
+    } else {
+      return JSON.parse(parsedBody);
+    }
+    // return data ? JSON.parse(body?.[data]) : body;
   },
 );


### PR DESCRIPTION
## 이슈
- #119

## 체크리스트
- nickname 수정 구현
- 프로필 사진 수정 구현

## 고민한 내용
### 이미지 처리에 대한 이슈
원래는 이미지에 대한 상태를 undefined, null 두개로 나누어서 undefined면 변경을 하지 않고 null이면 기본사진으로 변경하는 로직을 계획했었는데 file에 null을 넣어서 보낼 수 가 없었다. 그래서 json body에 이미지 수정 여부를 보내게 하여 처리하도록 수정하였다.

## 스크린샷
