### PR TITLE
[BE/#134] GET /posts/block API 구현

### DIFF
--- a/BE/src/entities/blockPost.entity.ts
+++ b/BE/src/entities/blockPost.entity.ts
@@ -17,7 +17,7 @@ export class BlockPostEntity {
   @JoinColumn({ name: 'blocker' })
   blockerUser: UserEntity;
 
-  @ManyToOne(() => UserEntity, (blocked_post) => blocked_post.id)
+  @ManyToOne(() => PostEntity, (blocked_post) => blocked_post.id)
   @JoinColumn({ name: 'blocked_post' })
   blockedPost: PostEntity;
 }

--- a/BE/src/entities/blockPost.entity.ts
+++ b/BE/src/entities/blockPost.entity.ts
@@ -14,7 +14,7 @@ export class BlockPostEntity {
   status: boolean;
 
   @ManyToOne(() => UserEntity, (blocker) => blocker.user_hash)
-  @JoinColumn({ name: 'blocker' })
+  @JoinColumn({ name: 'blocker', referencedColumnName: 'user_hash' })
   blockerUser: UserEntity;
 
   @ManyToOne(() => PostEntity, (blocked_post) => blocked_post.id)

--- a/BE/src/entities/post.entity.ts
+++ b/BE/src/entities/post.entity.ts
@@ -64,5 +64,5 @@ export class PostEntity {
   post_images: PostImageEntity[];
 
   @OneToMany(() => BlockPostEntity, (post_image) => post_image.blocked_post)
-  blocked_posts: PostImageEntity[];
+  blocked_posts: BlockPostEntity[];
 }

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -64,6 +64,7 @@ export class PostService {
         price: res.price,
         user_id: res.user_id,
         images: res.post_images,
+        post_image: res.thumbnail,
         is_request: res.is_request,
         start_date: res.start_date,
         end_date: res.end_date,
@@ -140,6 +141,7 @@ export class PostService {
     post.end_date = createPostDto.end_date;
     post.status = true;
     post.user_id = user.id;
+    post.thumbnail = imageLocations.length > 0 ? imageLocations[0] : null;
     // 이미지 추가
     const res = await this.postRepository.save(post);
     if (res.is_request === false) {

--- a/BE/src/posts-block/posts-block.controller.ts
+++ b/BE/src/posts-block/posts-block.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Param, Post } from '@nestjs/common';
+import { Controller, Get, Param, Post } from '@nestjs/common';
 import { PostsBlockService } from './posts-block.service';
 
 @Controller('posts/block')
@@ -8,5 +8,12 @@ export class PostsBlockController {
   async postsBlockCreate(@Param('id') postId: number) {
     const blockerId = 'qwe';
     await this.postsBlockService.createPostsBlock(blockerId, postId);
+  }
+
+  @Get()
+  async postsBlockList() {
+    const blockerId: string = 'qwe';
+    const blockedPosts =
+      await this.postsBlockService.findBlockedPosts(blockerId);
   }
 }

--- a/BE/src/posts-block/posts-block.controller.ts
+++ b/BE/src/posts-block/posts-block.controller.ts
@@ -15,5 +15,6 @@ export class PostsBlockController {
     const blockerId: string = 'qwe';
     const blockedPosts =
       await this.postsBlockService.findBlockedPosts(blockerId);
+    return blockedPosts;
   }
 }

--- a/BE/src/posts-block/posts-block.service.ts
+++ b/BE/src/posts-block/posts-block.service.ts
@@ -26,7 +26,7 @@ export class PostsBlockService {
         blocked_post: postId,
       },
     });
-    if (isExist.status === true) {
+    if (isExist !== null && isExist.status === true) {
       throw new HttpException('이미 차단 되었습니다.', 400);
     }
     blockPostEntity.blocked_post = postId;

--- a/BE/src/posts-block/posts-block.service.ts
+++ b/BE/src/posts-block/posts-block.service.ts
@@ -34,4 +34,22 @@ export class PostsBlockService {
     blockPostEntity.status = true;
     await this.blockPostRepository.save(blockPostEntity);
   }
+
+  async findBlockedPosts(blockerId: string) {
+    const blockLists = await this.blockPostRepository.find({
+      where: {
+        blocker: blockerId,
+        status: true,
+      },
+      relations: ['blockedPost'],
+    });
+    return blockLists.map((blockList) => {
+      const blockedPost = blockList.blockedPost;
+      return {
+        title: blockedPost.title,
+        post_image: blockedPost.thumbnail,
+        post_id: blockedPost.id,
+      };
+    });
+  }
 }


### PR DESCRIPTION
## 이슈
- #134

## 체크리스트
- 유저가 차단한 게시물의 목록을 반환하는 기능 구현
- 게시글 차단 코드에서 이미 존재하는지 확인하는 코드에 null 이 들어오면 에러 뜨는오류 수정

## 고민한 내용
### null 들어오면 오류 나는 이슈
`isExist.status === true` 에서 isExist 에서 존재 하지 않으면 null 반환되고 null.status는 null이라고 생각하여 이렇게 구현했었는데 null에 프로퍼티를 찾는 연산을 하면 에러가 떴다.
그래서 null이면 조건문을 통과하도록 수정하였다.

### Join 에러
엔티티를 정확하게 작성하지 않아 join이 되지 않는 오류가 발생하였다. 엔티티의 join 관계를 정확히 수정하니 정상적으로 작동하였다.

### thumbnail
차단된 게시글의 내용과 게시글의 첫번째 사진을 반환해야했는데 사진을 또 찾으려면 3중 조인을 해야해서 비효율적이라 생각이 들어 게시글을 저장 할 떄 첫번째 사진은 게시글 테이블 안에 저장하도록 수정했다.

## 스크린샷
