### PR TITLE
[iOS/#146] 게시글 등록 View, ViewModel 바인딩

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		5975E98B2B035919007CEF13 /* Posts.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9882B035919007CEF13 /* Posts.json */; };
 		5975E98C2B035919007CEF13 /* Users.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9892B035919007CEF13 /* Users.json */; };
 		5979BA7C2B08AE3C00FFF215 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5979BA7B2B08AE3C00FFF215 /* UITextField+.swift */; };
+		5980D75F2B0FB6DB00A6B370 /* PostingRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5980D75E2B0FB6DB00A6B370 /* PostingRepository.swift */; };
 		59AABDDF2B0E1AE1002F6D0E /* PostingTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDDE2B0E1AE1002F6D0E /* PostingTitleView.swift */; };
 		59AABDE12B0E1BB8002F6D0E /* PostingPriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE02B0E1BB8002F6D0E /* PostingPriceView.swift */; };
 		59AABDE32B0E272C002F6D0E /* PostingTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE22B0E272C002F6D0E /* PostingTimeView.swift */; };
@@ -89,6 +90,7 @@
 		5975E9882B035919007CEF13 /* Posts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Posts.json; sourceTree = "<group>"; };
 		5975E9892B035919007CEF13 /* Users.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Users.json; sourceTree = "<group>"; };
 		5979BA7B2B08AE3C00FFF215 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
+		5980D75E2B0FB6DB00A6B370 /* PostingRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingRepository.swift; sourceTree = "<group>"; };
 		59AA129A2B03726C00AFC766 /* VillageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VillageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		59AABDDE2B0E1AE1002F6D0E /* PostingTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingTitleView.swift; sourceTree = "<group>"; };
 		59AABDE02B0E1BB8002F6D0E /* PostingPriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingPriceView.swift; sourceTree = "<group>"; };
@@ -216,6 +218,7 @@
 			isa = PBXGroup;
 			children = (
 				59DC1B1E2B0C6AEC004C8C1A /* PostingViewModel.swift */,
+				5980D75E2B0FB6DB00A6B370 /* PostingRepository.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -621,6 +624,7 @@
 				59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */,
 				8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */,
 				8F1B53382B0E03AE006D8982 /* PostResponseDTO.swift in Sources */,
+				5980D75F2B0FB6DB00A6B370 /* PostingRepository.swift in Sources */,
 				4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */,
 				8F95CF982B0C7B270024631F /* Reponsable.swift in Sources */,
 				8F95CF922B0C57460024631F /* NetworkError.swift in Sources */,

--- a/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
@@ -97,13 +97,15 @@ final class HomeViewController: UIViewController {
     
     private func setMenuUI() {
         let presentPostRequestNC = UIAction(title: "대여 요청하기") { [weak self] _ in
-            let postRequestVC = PostingViewController(viewModel: PostingViewModel(), type: .request)
+            let viewModel = PostingViewModel(repository: PostingRepository())
+            let postRequestVC = PostingViewController(viewModel: viewModel, type: .request)
             let postRequestNC = UINavigationController(rootViewController: postRequestVC)
             postRequestNC.modalPresentationStyle = .fullScreen
             self?.present(postRequestNC, animated: true)
         }
         let presentPostRentNC = UIAction(title: "대여 등록하기") { [weak self] _ in
-            let postRentVC = PostingViewController(viewModel: PostingViewModel(), type: .rent)
+            let viewModel = PostingViewModel(repository: PostingRepository())
+            let postRentVC = PostingViewController(viewModel: viewModel, type: .rent)
             let postRentNC = UINavigationController(rootViewController: postRentVC)
             postRentNC.modalPresentationStyle = .fullScreen
             self?.present(postRentNC, animated: true)

--- a/iOS/Village/Village/Presentation/PostDetail/Custom/PriceLabel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/PriceLabel.swift
@@ -41,9 +41,8 @@ final class PriceLabel: UIView {
     }
     
     func setPrice(price: Int?) {
-        guard let price = price,
-              let priceText = price.priceText() else { return }
-        
+        guard let price = price else { return }
+        let priceText = price.priceText()
         priceLabel.text = "\(priceText)원"
     }
     

--- a/iOS/Village/Village/Presentation/Posting/View/Custom/PostingDetailView.swift
+++ b/iOS/Village/Village/Presentation/Posting/View/Custom/PostingDetailView.swift
@@ -6,8 +6,11 @@
 //
 
 import UIKit
+import Combine
 
 final class PostingDetailView: UIStackView {
+    
+    var currentDetailSubject = CurrentValueSubject<String, Never>("")
     
     private let detailHeaderLabel: UILabel = {
         let label = UILabel()
@@ -98,6 +101,7 @@ extension PostingDetailView: UITextViewDelegate {
                 constraint.constant = estimatedSize.height
             }
         }
+        currentDetailSubject.send(textView.text)
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/iOS/Village/Village/Presentation/Posting/View/Custom/PostingTitleView.swift
+++ b/iOS/Village/Village/Presentation/Posting/View/Custom/PostingTitleView.swift
@@ -10,6 +10,8 @@ import Combine
 
 final class PostingTitleView: UIStackView {
     
+    var currentTextSubject = CurrentValueSubject<String, Never>("")
+    
     private lazy var keyboardToolBar: UIToolbar = {
         let toolbar = UIToolbar()
         let hideKeyboardButton = UIBarButtonItem(
@@ -80,15 +82,13 @@ final class PostingTitleView: UIStackView {
         endEditing(true)
     }
     
-    @objc private func textFieldDidChanged(_ sender: UITextField) {
-        titleWarningLabel.alpha = 0
+    @objc private func textFieldDidChanged() {
+        currentTextSubject.send(titleTextField.text ?? "")
     }
     
-    func warn() {
-        guard let text = titleTextField.text else { return }
-        if text.isEmpty {
-            titleWarningLabel.alpha = 1
-        }
+    func warn(_ enable: Bool) {
+        let alpha: CGFloat = enable ? 1 : 0
+        titleWarningLabel.alpha = alpha
     }
     
 }
@@ -129,17 +129,6 @@ extension PostingTitleView: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
-    }
-    
-}
-
-extension PostingTitleView {
-    
-    var publisher: AnyPublisher<String, Never> {
-        NotificationCenter.default.publisher(for: UITextField.textDidChangeNotification, object: titleTextField)
-            .compactMap { $0.object as? UITextField }
-            .map { $0.text ?? "" }
-            .eraseToAnyPublisher()
     }
     
 }

--- a/iOS/Village/Village/Presentation/Posting/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/Posting/ViewModel/PostCreateViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  PostingViewModel.swift
+//  PostCreateViewModel.swift
 //  Village
 //
 //  Created by 조성민 on 11/21/23.
@@ -8,7 +8,7 @@
 import Foundation
 import Combine
 
-final class PostingViewModel {
+final class PostCreateViewModel {
     
     private var titleInput: String = ""
     private var startTimeInput: Date?
@@ -25,9 +25,9 @@ final class PostingViewModel {
     
     private var cancellableBag = Set<AnyCancellable>()
     
-    private let repository: PostingRepository
+    private let repository: PostCreateRepository
     
-    init(repository: PostingRepository) {
+    init(repository: PostCreateRepository) {
         self.repository = repository
     }
     
@@ -89,7 +89,7 @@ final class PostingViewModel {
     
 }
 
-private extension PostingViewModel {
+private extension PostCreateViewModel {
     
     func validateTitle() {
         let result = !titleInput.isEmpty
@@ -113,7 +113,7 @@ private extension PostingViewModel {
     
 }
 
-extension PostingViewModel {
+extension PostCreateViewModel {
     
     struct Input {
         

--- a/iOS/Village/Village/Presentation/Posting/ViewModel/PostingRepository.swift
+++ b/iOS/Village/Village/Presentation/Posting/ViewModel/PostingRepository.swift
@@ -1,0 +1,12 @@
+//
+//  PostingRepository.swift
+//  Village
+//
+//  Created by 조성민 on 11/23/23.
+//
+
+import Foundation
+
+class PostingRepository {
+    
+}

--- a/iOS/Village/Village/Presentation/Utils/Extensions/Int+.swift
+++ b/iOS/Village/Village/Presentation/Utils/Extensions/Int+.swift
@@ -9,10 +9,10 @@ import Foundation
 
 extension Int {
     
-    func priceText() -> String? {
+    func priceText() -> String {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        return formatter.string(for: self)
+        return formatter.string(for: self)!
     }
     
 }


### PR DESCRIPTION
## 이슈
- #146 

## 체크리스트
- [x] Combine을 이용하여 View와 ViewModel을 바인딩한다.
- [x] UITextField의 유효성 검사를 ViewModel의 로직으로 옮긴다.

## 고민한 내용
- 로직은 View가 아닌 ViewModel에 있어야 한다고 판단하여 View에 있는 로직을 ViewModel로 옮겼습니다.
- View의 변화는 ViewModel로 Combine을 통해서 전달되고 결과값을 반영하여 View에 영향을 줘야 할 때에는 Output으로 View를 변화시키기도 했습니다.

## 스크린샷
![image](https://github.com/boostcampwm2023/iOS05-Village/assets/128480641/9ce89027-6f3f-4e66-903c-5bfc9917360a)
