### PR TITLE
게시글 조회 기능 구현

### DIFF
--- a/BE/src/entities/post.entity.ts
+++ b/BE/src/entities/post.entity.ts
@@ -33,7 +33,7 @@ export class PostEntity {
   @JoinColumn({ name: 'user_id' })
   user: UserEntity;
 
-  @Column({ type: 'tinyint', nullable: false })
+  @Column({ type: 'boolean', nullable: false })
   status: boolean;
 
   @Column({ type: 'datetime', nullable: false })
@@ -42,7 +42,7 @@ export class PostEntity {
   @Column({ type: 'datetime', nullable: false })
   end_date: Date;
 
-  @Column({ type: 'tinyint', nullable: false })
+  @Column({ type: 'boolean', nullable: false })
   is_request: boolean;
 
   @CreateDateColumn({

--- a/BE/src/post/post.controller.ts
+++ b/BE/src/post/post.controller.ts
@@ -1,17 +1,16 @@
 import {
-  Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpException,
   Param,
   Patch,
   Post,
+  Query,
   UploadedFiles,
   UseInterceptors,
   ValidationPipe,
-  Delete,
-  Query,
 } from '@nestjs/common';
 import { PostService } from './post.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -54,15 +53,8 @@ export class PostController {
   @Get('/:id')
   @ApiOperation({ summary: 'search for post', description: '게시글 상세 조회' })
   async postDetails(@Param('id') id: number) {
-    const post = await this.postService.findPostById(id);
-
-    if (post) {
-      return post;
-    } else if (post === null) {
-      throw new HttpException('게시글이 존재하지 않습니다.', 404);
-    } else {
-      throw new HttpException('서버 오류입니다.', 500);
-    }
+    const userId = 'qwe';
+    return await this.postService.findPostById(id, userId);
   }
 
   @Patch('/:id')

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -67,7 +67,7 @@ export class PostService {
       take: limit,
       skip: offset,
       where: this.makeWhereOption(query),
-      relations: ['post_images'],
+      relations: ['post_images', 'user'],
     });
     res = this.filterBlocked(res, blockedUsers, blockedPosts);
     const posts = [];
@@ -77,7 +77,7 @@ export class PostService {
         price: re.price,
         description: re.contents,
         post_id: re.id,
-        user_id: re.user_id,
+        user_id: re.user.user_hash,
         is_request: re.is_request === true ? true : false,
         images: re.post_images.map((post_image) => post_image.image_url),
         start_date: re.start_date,
@@ -92,14 +92,14 @@ export class PostService {
     try {
       const res = await this.postRepository.findOne({
         where: { id: postId },
-        relations: ['post_images'],
+        relations: ['post_images', 'user'],
       });
 
       const post = {
         title: res.title,
         description: res.contents,
         price: res.price,
-        user_id: res.user_id,
+        user_id: res.user.user_hash,
         images: res.post_images.map((post_image) => post_image.image_url),
         is_request: res.is_request === true ? true : false,
         start_date: res.start_date,

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -78,7 +78,7 @@ export class PostService {
         description: re.contents,
         post_id: re.id,
         user_id: re.user.user_hash,
-        is_request: re.is_request === true ? true : false,
+        is_request: re.is_request,
         images: re.post_images.map((post_image) => post_image.image_url),
         start_date: re.start_date,
         end_date: re.end_date,
@@ -95,18 +95,17 @@ export class PostService {
         relations: ['post_images', 'user'],
       });
 
-      const post = {
+      return {
         title: res.title,
         description: res.contents,
         price: res.price,
         user_id: res.user.user_hash,
         images: res.post_images.map((post_image) => post_image.image_url),
-        is_request: res.is_request === true ? true : false,
+        is_request: res.is_request,
         start_date: res.start_date,
         end_date: res.end_date,
+        post_id: res.id,
       };
-
-      return post;
     } catch {
       return null;
     }

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -55,7 +55,7 @@ export class PostService {
   async findPosts(query: PostListDto, userId: string) {
     const page: number = query.page === undefined ? 1 : query.page;
     const limit: number = 20;
-    const offset: number = limit * (page - 1) + 1;
+    const offset: number = limit * (page - 1);
     const blockedUsers = await this.blockUserRepository.find({
       where: { blocker: userId },
       relations: ['blockedUser'],


### PR DESCRIPTION
## 이슈
- #167

## 체크리스트
- 게시글 0번째 부터 나오도록 수정
- 게시글 정보에서 유저 id 대시 hash 값이 들어가도록 수정
- 차단하는 게시글을 조회하는 경우 에러가 응답되도록 추가
-  post 엔티티에서 boolean 값들의 mysql 타입을 boolean으로 수정

## 고민한 내용
- TypeORM에서 `@Column({ type: 'tinyint', nullable: false })` 과 같이 mysql 에서 boolean 타입이 없어서 tinyint로 설정했기에 엔티티에도 동일하게 설정하였더니 자료형이 boolean이 아니라 int 형으로 0, 1 이 저장되었다.
- 그래서 `@Column({ type: 'boolean', nullable: false })` 이렇게 타입을 변경하니 정상적으로 boolean 타입으로 반환되었다.
- 차단된 게시글의 상세화면의 요청에 대해서 예외처리를 할지 말지 고민 하였는데 우리의 iOS 클라이언트 외에도 요청이 들어올수 있기 때문에 예외 처리를 진행하였다.

## 스크린샷
