### PR TITLE
[BE/#118] DELETE API 구현 및 삭제 관련 로직 수정

### DIFF
--- a/BE/src/entities/blockPost.entity.ts
+++ b/BE/src/entities/blockPost.entity.ts
@@ -17,9 +17,6 @@ export class BlockPostEntity {
   @PrimaryColumn()
   blocked_post: number;
 
-  @Column({ nullable: false, default: true })
-  status: boolean;
-
   @DeleteDateColumn()
   delete_date: Date;
 

--- a/BE/src/entities/blockUser.entity.ts
+++ b/BE/src/entities/blockUser.entity.ts
@@ -17,9 +17,6 @@ export class BlockUserEntity {
   @PrimaryColumn()
   blocked_user: string;
 
-  @Column({ nullable: false, default: true })
-  status: boolean;
-
   @DeleteDateColumn()
   delete_date: Date;
 

--- a/BE/src/entities/post.entity.ts
+++ b/BE/src/entities/post.entity.ts
@@ -34,9 +34,6 @@ export class PostEntity {
   @JoinColumn({ name: 'user_id' })
   user: UserEntity;
 
-  @Column({ type: 'boolean', nullable: false })
-  status: boolean;
-
   @Column({ type: 'datetime', nullable: false })
   start_date: Date;
 

--- a/BE/src/entities/user.entity.ts
+++ b/BE/src/entities/user.entity.ts
@@ -49,9 +49,6 @@ export class UserEntity {
   })
   update_date: Date;
 
-  @Column({ type: 'tinyint', nullable: false, default: true })
-  status: boolean;
-
   @Column({ length: 2048, nullable: true, charset: 'utf8' })
   profile_img: string;
 

--- a/BE/src/post/post.controller.ts
+++ b/BE/src/post/post.controller.ts
@@ -83,7 +83,7 @@ export class PostController {
 
   @Delete('/:id')
   async postRemove(@Param('id') id: number) {
-    const isRemoved = await this.postService.deletePostById(id);
+    const isRemoved = await this.postService.removePost(id);
 
     if (isRemoved) {
       return HttpCode(200);

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -108,7 +108,7 @@ export class PostService {
 
     console.log(post);
     if (post === null) {
-      throw new HttpException('없는 게시물입니다.', 400);
+      throw new HttpException('없는 게시물입니다.', 404);
     }
     if (await this.isFiltered(post, userId)) {
       throw new HttpException('차단한 게시물입니다.', 400);

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -226,7 +226,7 @@ export class PostService {
     }
   }
 
-  async deletePostById(postId: number) {
+  async removePost(postId: number) {
     const isDataExists = await this.postRepository.findOne({
       where: { id: postId, status: true },
     });
@@ -234,8 +234,13 @@ export class PostService {
     if (!isDataExists) {
       return false;
     } else {
-      await this.postRepository.softDelete({ id: postId });
+      await this.deleteCascadingPost(postId);
       return true;
     }
+  }
+  async deleteCascadingPost(postId: number) {
+    await this.postImageRepository.softDelete({ post_id: postId });
+    await this.blockPostRepository.softDelete({ blocked_post: postId });
+    await this.postRepository.softDelete({ id: postId });
   }
 }

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -26,7 +26,7 @@ export class PostService {
     private s3Handler: S3Handler,
   ) {}
   makeWhereOption(query: PostListDto) {
-    const where = { status: true, is_request: undefined };
+    const where = { is_request: undefined };
     if (query.requestFilter !== undefined) {
       where.is_request = query.requestFilter !== 0;
     }
@@ -106,7 +106,6 @@ export class PostService {
       relations: ['post_images', 'user'],
     });
 
-    console.log(post);
     if (post === null) {
       throw new HttpException('없는 게시물입니다.', 404);
     }
@@ -207,7 +206,6 @@ export class PostService {
     post.is_request = createPostDto.is_request;
     post.start_date = createPostDto.start_date;
     post.end_date = createPostDto.end_date;
-    post.status = true;
     post.user_id = user.id;
     post.thumbnail = imageLocations.length > 0 ? imageLocations[0] : null;
     // 이미지 추가
@@ -228,7 +226,7 @@ export class PostService {
 
   async removePost(postId: number) {
     const isDataExists = await this.postRepository.findOne({
-      where: { id: postId, status: true },
+      where: { id: postId },
     });
 
     if (!isDataExists) {

--- a/BE/src/posts-block/posts-block.controller.ts
+++ b/BE/src/posts-block/posts-block.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Param, Post } from '@nestjs/common';
+import { Controller, Delete, Get, Param, Post } from '@nestjs/common';
 import { PostsBlockService } from './posts-block.service';
 
 @Controller('posts/block')
@@ -13,8 +13,12 @@ export class PostsBlockController {
   @Get()
   async postsBlockList() {
     const blockerId: string = 'qwe';
-    const blockedPosts =
-      await this.postsBlockService.findBlockedPosts(blockerId);
-    return blockedPosts;
+    return await this.postsBlockService.findBlockedPosts(blockerId);
+  }
+
+  @Delete(':id')
+  async blockUserRemove(@Param('id') id: number) {
+    const userId = 'qwe';
+    await this.postsBlockService.removeBlockPosts(id, userId);
   }
 }

--- a/BE/src/posts-block/posts-block.service.ts
+++ b/BE/src/posts-block/posts-block.service.ts
@@ -43,7 +43,6 @@ export class PostsBlockService {
       const blockPostEntity = new BlockPostEntity();
       blockPostEntity.blocked_post = postId;
       blockPostEntity.blocker = blockerId;
-      blockPostEntity.status = true;
       await this.blockPostRepository.save(blockPostEntity);
     }
   }

--- a/BE/src/posts-block/posts-block.service.ts
+++ b/BE/src/posts-block/posts-block.service.ts
@@ -27,24 +27,16 @@ export class PostsBlockService {
       },
       withDeleted: true,
     });
-    if (isExist) {
-      if (isExist.delete_date === null) {
-        throw new HttpException('이미 차단 되었습니다.', 400);
-      } else {
-        await this.blockPostRepository.update(
-          {
-            blocker: blockerId,
-            blocked_post: postId,
-          },
-          { delete_date: null },
-        );
-      }
-    } else {
-      const blockPostEntity = new BlockPostEntity();
-      blockPostEntity.blocked_post = postId;
-      blockPostEntity.blocker = blockerId;
-      await this.blockPostRepository.save(blockPostEntity);
+
+    if (isExist !== null && isExist.delete_date === null) {
+      throw new HttpException('이미 차단 되었습니다.', 400);
     }
+
+    const blockPostEntity = new BlockPostEntity();
+    blockPostEntity.blocked_post = postId;
+    blockPostEntity.blocker = blockerId;
+    blockPostEntity.delete_date = null;
+    await this.blockPostRepository.save(blockPostEntity);
   }
 
   async findBlockedPosts(blockerId: string) {

--- a/BE/src/users-block/users-block.controller.ts
+++ b/BE/src/users-block/users-block.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, Delete } from '@nestjs/common';
+import { Controller, Get, Post, Param, Delete } from '@nestjs/common';
 import { UsersBlockService } from './users-block.service';
 
 @Controller('users/block')
@@ -13,11 +13,13 @@ export class UsersBlockController {
 
   @Post('/:id')
   async blockUserAdd(@Param('id') id: string) {
-    await this.usersBlockService.addBlockUser(id);
+    const userId = 'qwe';
+    await this.usersBlockService.addBlockUser(id, userId);
   }
 
   @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.usersBlockService.remove(+id);
+  async blockUserRemove(@Param('id') id: string) {
+    const userId = 'qwe';
+    await this.usersBlockService.removeBlockUser(id, userId);
   }
 }

--- a/BE/src/users-block/users-block.service.ts
+++ b/BE/src/users-block/users-block.service.ts
@@ -42,7 +42,6 @@ export class UsersBlockService {
       const blockUserEntity = new BlockUserEntity();
       blockUserEntity.blocker = userId;
       blockUserEntity.blocked_user = id;
-      blockUserEntity.status = true;
 
       try {
         return await this.blockUserRepository.save(blockUserEntity);
@@ -54,7 +53,7 @@ export class UsersBlockService {
 
   async getBlockUser(id: string) {
     const res = await this.blockUserRepository.find({
-      where: { blocker: id, status: true },
+      where: { blocker: id },
       relations: ['blockedUser'],
     });
 

--- a/BE/src/users-block/users-block.service.ts
+++ b/BE/src/users-block/users-block.service.ts
@@ -26,28 +26,19 @@ export class UsersBlockService {
       where: { blocked_user: id, blocker: userId },
       withDeleted: true,
     });
-    if (isBlockedUser) {
-      if (isBlockedUser.delete_date === null) {
-        throw new HttpException('이미 차단된 유저입니다', 400);
-      } else {
-        await this.blockUserRepository.update(
-          {
-            blocker: userId,
-            blocked_user: id,
-          },
-          { delete_date: null },
-        );
-      }
-    } else {
-      const blockUserEntity = new BlockUserEntity();
-      blockUserEntity.blocker = userId;
-      blockUserEntity.blocked_user = id;
 
-      try {
-        return await this.blockUserRepository.save(blockUserEntity);
-      } catch (e) {
-        throw new HttpException('서버 오류입니다', 500);
-      }
+    if (isBlockedUser !== null && isBlockedUser.delete_date === null) {
+      throw new HttpException('이미 차단된 유저입니다', 400);
+    }
+    const blockUserEntity = new BlockUserEntity();
+    blockUserEntity.blocker = userId;
+    blockUserEntity.blocked_user = id;
+    blockUserEntity.delete_date = null;
+
+    try {
+      return await this.blockUserRepository.save(blockUserEntity);
+    } catch (e) {
+      throw new HttpException('서버 오류입니다', 500);
     }
   }
 

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Get,
   Post,
-  Body,
   Patch,
   Param,
   Delete,
@@ -50,8 +49,8 @@ export class UsersController {
   }
 
   @Delete(':id')
-  usersRemove(@Param('id') id: string) {
-    return this.usersService.removeUser(+id);
+  async usersRemove(@Param('id') id: string) {
+    await this.usersService.removeUser(id);
   }
 
   @Patch(':id')

--- a/BE/src/users/users.module.ts
+++ b/BE/src/users/users.module.ts
@@ -4,9 +4,21 @@ import { UsersController } from './users.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { S3Handler } from 'src/utils/S3Handler';
 import { UserEntity } from '../entities/user.entity';
+import { PostEntity } from '../entities/post.entity';
+import { PostImageEntity } from '../entities/postImage.entity';
+import { BlockUserEntity } from '../entities/blockUser.entity';
+import { BlockPostEntity } from '../entities/blockPost.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([UserEntity])],
+  imports: [
+    TypeOrmModule.forFeature([
+      PostEntity,
+      UserEntity,
+      PostImageEntity,
+      BlockUserEntity,
+      BlockPostEntity,
+    ]),
+  ],
   controllers: [UsersController],
   providers: [UsersService, S3Handler],
 })

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -35,14 +35,13 @@ export class UsersService {
     userEntity.OAuth_domain = createUserDto.OAuth_domain;
     userEntity.profile_img = imageLocation;
     userEntity.user_hash = hashMaker(createUserDto.nickname).slice(0, 8);
-    userEntity.status = true;
     const res = await this.userRepository.save(userEntity);
     return res;
   }
 
   async findUserById(userId: string) {
     const user: UserEntity = await this.userRepository.findOne({
-      where: { user_hash: userId, status: true },
+      where: { user_hash: userId },
     });
     if (user) {
       return { nickname: user.nickname, profile_img: user.profile_img };
@@ -53,7 +52,7 @@ export class UsersService {
 
   async removeUser(id: string) {
     const isDataExists = await this.userRepository.findOne({
-      where: { user_hash: id, status: true },
+      where: { user_hash: id },
     });
     if (!isDataExists) {
       return false;

--- a/BE/src/utils/hashMaker.ts
+++ b/BE/src/utils/hashMaker.ts
@@ -4,5 +4,5 @@ export const hashMaker = (nickname: string) => {
   return crypto
     .createHash('sha256')
     .update(nickname + new Date().getTime())
-    .digest('base64');
+    .digest('base64url');
 };


### PR DESCRIPTION
## 이슈
- #118

## 체크리스트
- [x] DELETE API 구현
- [x] status entity 삭제

## 고민한 내용
- 유저나 게시글을 삭제 할 때 조인 되어있는 다른 데이터들이 한번에 삭제 되어야하는데 이것을 typeORM의 cascade 기능을 사용하여 구현하려 했지만 잘 동작이 되지 않아 수동으로 연관되어 있는 테이블의 데이터를 삭제하도록 구현하였다.

## 스크린샷
