### PR TITLE
[iOS/#195] 회원가입 화면 UI 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		440FCC2D2B04EB940011B637 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 440FCC2C2B04EB940011B637 /* Constants.swift */; };
+		4416D4502B14A4420052BF33 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4416D44F2B14A4420052BF33 /* SignUpViewController.swift */; };
+		4416D4532B14AB300052BF33 /* ProfileImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4416D4522B14AB300052BF33 /* ProfileImageView.swift */; };
+		4416D4552B14B5F00052BF33 /* NicknameTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4416D4542B14B5F00052BF33 /* NicknameTextField.swift */; };
 		442442172B14427F009D39A8 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442442162B14427F009D39A8 /* LoginViewController.swift */; };
 		44425A642B038AEA00AAD64A /* FloatingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44425A632B038AEA00AAD64A /* FloatingButton.swift */; };
 		444A50902B0C60F900454397 /* ImagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444A508F2B0C60F900454397 /* ImagePageView.swift */; };
@@ -83,6 +86,9 @@
 
 /* Begin PBXFileReference section */
 		440FCC2C2B04EB940011B637 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		4416D44F2B14A4420052BF33 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
+		4416D4522B14AB300052BF33 /* ProfileImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageView.swift; sourceTree = "<group>"; };
+		4416D4542B14B5F00052BF33 /* NicknameTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameTextField.swift; sourceTree = "<group>"; };
 		442442162B14427F009D39A8 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		44425A632B038AEA00AAD64A /* FloatingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButton.swift; sourceTree = "<group>"; };
 		444A508F2B0C60F900454397 /* ImagePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePageView.swift; sourceTree = "<group>"; };
@@ -171,6 +177,32 @@
 				440FCC2C2B04EB940011B637 /* Constants.swift */,
 			);
 			path = Common;
+			sourceTree = "<group>";
+		};
+		4416D44D2B14A4260052BF33 /* SignUp */ = {
+			isa = PBXGroup;
+			children = (
+				4416D44E2B14A4310052BF33 /* View */,
+			);
+			path = SignUp;
+			sourceTree = "<group>";
+		};
+		4416D44E2B14A4310052BF33 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				4416D4512B14A47F0052BF33 /* Custom */,
+				4416D44F2B14A4420052BF33 /* SignUpViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		4416D4512B14A47F0052BF33 /* Custom */ = {
+			isa = PBXGroup;
+			children = (
+				4416D4522B14AB300052BF33 /* ProfileImageView.swift */,
+				4416D4542B14B5F00052BF33 /* NicknameTextField.swift */,
+			);
+			path = Custom;
 			sourceTree = "<group>";
 		};
 		442442152B144268009D39A8 /* Login */ = {
@@ -395,6 +427,7 @@
 			isa = PBXGroup;
 			children = (
 				442442152B144268009D39A8 /* Login */,
+				4416D44D2B14A4260052BF33 /* SignUp */,
 				8FF7E6082B0F38A500B6D678 /* ChatList */,
 				8F95CF8E2B0B97BA0024631F /* Commons */,
 				8FBE3B062B04763200660530 /* Home */,
@@ -673,10 +706,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4416D4502B14A4420052BF33 /* SignUpViewController.swift in Sources */,
 				44C1F5DF2B0FA8400047A436 /* Assets.xcassets in Sources */,
 				59BD5DCE2B0C775D00FEB80F /* SceneDelegate.swift in Sources */,
 				59BD5DCD2B0C775200FEB80F /* FloatingButton.swift in Sources */,
 				59BD5DCC2B0C772200FEB80F /* PostCreateViewController.swift in Sources */,
+				4416D4532B14AB300052BF33 /* ProfileImageView.swift in Sources */,
 				8F1B53322B0DE0D8006D8982 /* APIEndPoints.swift in Sources */,
 				59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */,
 				8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */,
@@ -735,6 +770,7 @@
 				8FF7E60C2B0F38A500B6D678 /* ChatListCollectionViewCell.swift in Sources */,
 				8FC7FE7B2B07A89A00B91D3B /* PostDetailViewController.swift in Sources */,
 				8FC7FE7B2B07A89A00B91D3B /* PostDetailViewController.swift in Sources */,
+				4416D4552B14B5F00052BF33 /* NicknameTextField.swift in Sources */,
 				8FF7E60D2B0F38A500B6D678 /* ChatListViewController.swift in Sources */,
 				442442172B14427F009D39A8 /* LoginViewController.swift in Sources */,
 				446362D12B0F050600B74DA7 /* UserInfoView.swift in Sources */,

--- a/iOS/Village/Village/Common/Constants.swift
+++ b/iOS/Village/Village/Common/Constants.swift
@@ -24,5 +24,6 @@ enum ImageSystemName: String {
     case ellipsis
     case paperplane
     case checkmark
+    case cameraCircleFill = "camera.circle.fill"
     
 }

--- a/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
@@ -1,0 +1,80 @@
+//
+//  UIView.swift
+//  Village
+//
+//  Created by 정상윤 on 11/27/23.
+//
+
+import UIKit
+import Combine
+
+final class NicknameTextField: UIView {
+    
+    var nicknameText = PassthroughSubject<String, Never>()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "닉네임"
+        label.font = .boldSystemFont(ofSize: 15)
+        
+        return label
+    }()
+    
+    private lazy var textField: UITextField = {
+        let textField = UITextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.addTarget(self, action: #selector(textFieldDidChange), for: .valueChanged)
+        textField.leftViewMode = .always
+        textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+        textField.setLayer(borderColor: .systemGray4)
+        
+        return textField
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureUI()
+        setLayoutConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("should not be called")
+    }
+    
+    @objc
+    private func textFieldDidChange() {
+        nicknameText.send(textField.text ?? "")
+    }
+
+}
+
+private extension NicknameTextField {
+    
+    func configureUI() {
+        addSubview(stackView)
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(textField)
+    }
+    
+    func setLayoutConstraints() {
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        
+        textField.heightAnchor.constraint(equalToConstant: 45).isActive = true
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/SignUp/View/Custom/ProfileImageView.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/Custom/ProfileImageView.swift
@@ -1,0 +1,72 @@
+//
+//  ProfileImageView.swift
+//  Village
+//
+//  Created by 정상윤 on 11/27/23.
+//
+
+import UIKit
+
+final class ProfileImageView: UIView {
+
+    private lazy var profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.backgroundColor = .systemGray4
+        imageView.tintColor = .systemGray6
+        imageView.image = UIImage(systemName: ImageSystemName.personFill.rawValue)
+        imageView.layer.cornerRadius = 50
+        imageView.clipsToBounds = true
+        
+        return imageView
+    }()
+    
+    private lazy var photoImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.backgroundColor = .secondarySystemFill.withAlphaComponent(1)
+        imageView.tintColor = .white
+        imageView.image = UIImage(systemName: ImageSystemName.cameraCircleFill.rawValue)
+        imageView.layer.cornerRadius = 15
+        imageView.clipsToBounds = true
+        
+        return imageView
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureUI()
+        setLayoutConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("should not be called")
+    }
+
+}
+
+private extension ProfileImageView {
+    
+    func configureUI() {
+        addSubview(profileImageView)
+        addSubview(photoImageView)
+    }
+    
+    func setLayoutConstraints() {
+        NSLayoutConstraint.activate([
+            profileImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            profileImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            profileImageView.topAnchor.constraint(equalTo: topAnchor),
+            profileImageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            photoImageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            photoImageView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            photoImageView.widthAnchor.constraint(equalToConstant: 30),
+            photoImageView.heightAnchor.constraint(equalToConstant: 30)
+        ])
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
@@ -1,0 +1,97 @@
+//
+//  SignUpViewController.swift
+//  Village
+//
+//  Created by 정상윤 on 11/27/23.
+//
+
+import UIKit
+
+final class SignUpViewController: UIViewController {
+    
+    private lazy var navigationBar: UINavigationBar = {
+        let bar = UINavigationBar()
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        bar.tintColor = .label
+        
+        return bar
+    }()
+    
+    private lazy var doneButton: UIBarButtonItem = {
+        let button = UIBarButtonItem()
+        button.title = "완료"
+        button.isEnabled = false
+        
+        return button
+    }()
+    
+    private lazy var profileImageView: ProfileImageView = {
+        let imageView = ProfileImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(imageClicked)))
+        
+        return imageView
+    }()
+    
+    private lazy var nicknameTextField: NicknameTextField = {
+        let textField = NicknameTextField()
+        textField.translatesAutoresizingMaskIntoConstraints = false
+        
+        return textField
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureUI()
+        configureNavigationBar()
+        setLayoutConstraints()
+    }
+    
+    @objc
+    private func imageClicked() {
+        dump("Image Clicked")
+    }
+
+}
+
+private extension SignUpViewController {
+    
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+        view.addSubview(navigationBar)
+        view.addSubview(profileImageView)
+        view.addSubview(nicknameTextField)
+    }
+    
+    func configureNavigationBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = .systemBackground
+        navigationItem.title = "프로필 설정"
+        navigationBar.standardAppearance = appearance
+        navigationBar.pushItem(navigationItem, animated: false)
+        navigationBar.topItem?.rightBarButtonItem = doneButton
+    }
+    
+    func setLayoutConstraints() {
+        NSLayoutConstraint.activate([
+            navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navigationBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            profileImageView.widthAnchor.constraint(equalToConstant: 100),
+            profileImageView.heightAnchor.constraint(equalToConstant: 100),
+            profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            profileImageView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: 20)
+        ])
+        
+        NSLayoutConstraint.activate([
+            nicknameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            nicknameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            nicknameTextField.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: 20)
+        ])
+    }
+    
+}


### PR DESCRIPTION
## 이슈
- #195 

## 체크리스트
- [x] 프로필 사진 설정 UI 구현
- [x] 닉네임 UITextField 구현

## 고민한 내용
- 프로필 사진 UI 구현할 때 구석에 작은 카메라 넣는 것이 은근 까다로웠...
- 회원가입 로직이 바뀌어서 아마 마이페이지 화면으로 바뀔 것 같네요 하하핳

## 스크린샷
<image src="https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/d68e2c3a-6bb9-4014-9bd0-5020601bea60" width=300>