### PR TITLE
[BE] access token 검증 API 구현

### DIFF
--- a/BE/src/login/login.controller.ts
+++ b/BE/src/login/login.controller.ts
@@ -1,13 +1,13 @@
 import {
   Body,
   Controller,
+  Get,
   HttpException,
   Post,
   UseGuards,
 } from '@nestjs/common';
 import { LoginService, SocialProperties } from './login.service';
 import { AppleLoginDto } from './dto/appleLogin.dto';
-
 
 @Controller('login')
 export class LoginController {
@@ -37,4 +37,7 @@ export class LoginController {
   loginAdmin(@Body('user') user) {
     return this.loginService.loginAdmin(user);
   }
+
+  @Get('expire')
+  checkAccessToken() {}
 }

--- a/BE/src/login/login.controller.ts
+++ b/BE/src/login/login.controller.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { LoginService, SocialProperties } from './login.service';
 import { AppleLoginDto } from './dto/appleLogin.dto';
+import { AuthGuard } from '../utils/auth.guard';
 
 @Controller('login')
 export class LoginController {
@@ -39,5 +40,6 @@ export class LoginController {
   }
 
   @Get('expire')
+  @UseGuards(AuthGuard)
   checkAccessToken() {}
 }

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -22,7 +22,6 @@ async function bootstrap() {
   // app.useGlobalInterceptors(new HttpLoggerInterceptor());
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
   app.useWebSocketAdapter(new WsAdapter(app));
-  app.useGlobalGuards(new AuthGuard());
   app.useGlobalPipes(
     new ValidationPipe({
       transform: true,


### PR DESCRIPTION
## 이슈
- #216

## 체크리스트
- [x] access token 검증 API 구현
- [x] 전역 가드 삭제

## 고민한 내용
- use global guard 사용하니까 모든 요청에 대해 가드 처리가 되어서 삭제하고 필요한 부분만 설정했다.

## 스크린샷
