### PR TITLE
[iOS/#224] 키체인 관리자 객체 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		4416D47E2B171BF30052BF33 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4416D47D2B171BF30052BF33 /* LoginViewModel.swift */; };
 		4416D4832B171C730052BF33 /* AuthenticationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4416D4822B171C730052BF33 /* AuthenticationToken.swift */; };
 		4416D4862B171CE50052BF33 /* AppleOAuthDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4416D4852B171CE50052BF33 /* AppleOAuthDTO.swift */; };
+		4416D48C2B174C7A0052BF33 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4416D48B2B174C7A0052BF33 /* KeychainManager.swift */; };
+		4416D48E2B174CBA0052BF33 /* KeychainError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4416D48D2B174CBA0052BF33 /* KeychainError.swift */; };
 		442442172B14427F009D39A8 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 442442162B14427F009D39A8 /* LoginViewController.swift */; };
 		44425A642B038AEA00AAD64A /* FloatingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44425A632B038AEA00AAD64A /* FloatingButton.swift */; };
 		444A50902B0C60F900454397 /* ImagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444A508F2B0C60F900454397 /* ImagePageView.swift */; };
@@ -107,6 +109,8 @@
 		4416D47D2B171BF30052BF33 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		4416D4822B171C730052BF33 /* AuthenticationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationToken.swift; sourceTree = "<group>"; };
 		4416D4852B171CE50052BF33 /* AppleOAuthDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleOAuthDTO.swift; sourceTree = "<group>"; };
+		4416D48B2B174C7A0052BF33 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
+		4416D48D2B174CBA0052BF33 /* KeychainError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainError.swift; sourceTree = "<group>"; };
 		442442162B14427F009D39A8 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		44425A632B038AEA00AAD64A /* FloatingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingButton.swift; sourceTree = "<group>"; };
 		444A508F2B0C60F900454397 /* ImagePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePageView.swift; sourceTree = "<group>"; };
@@ -262,6 +266,15 @@
 			path = Entity;
 			sourceTree = "<group>";
 		};
+		4416D48A2B174C1C0052BF33 /* PersistentStorage */ = {
+			isa = PBXGroup;
+			children = (
+				4416D48D2B174CBA0052BF33 /* KeychainError.swift */,
+				4416D48B2B174C7A0052BF33 /* KeychainManager.swift */,
+			);
+			path = PersistentStorage;
+			sourceTree = "<group>";
+		};
 		442442152B144268009D39A8 /* Login */ = {
 			isa = PBXGroup;
 			children = (
@@ -312,6 +325,7 @@
 		5975E98D2B03591E007CEF13 /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				4416D48A2B174C1C0052BF33 /* PersistentStorage */,
 				8F1B53302B0DE0B3006D8982 /* Network */,
 				59AA12952B036BFC00AFC766 /* Dummy */,
 			);
@@ -803,7 +817,9 @@
 				59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */,
 				8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */,
 				8F1B53382B0E03AE006D8982 /* PostListResponseDTO.swift in Sources */,
+				4416D48C2B174C7A0052BF33 /* KeychainManager.swift in Sources */,
 				5980D75F2B0FB6DB00A6B370 /* PostCreateRepository.swift in Sources */,
+				4416D48E2B174CBA0052BF33 /* KeychainError.swift in Sources */,
 				8F1B53382B0E03AE006D8982 /* PostListResponseDTO.swift in Sources */,
 				8F1B53382B0E03AE006D8982 /* PostListResponseDTO.swift in Sources */,
 				5980D75F2B0FB6DB00A6B370 /* PostCreateRepository.swift in Sources */,

--- a/iOS/Village/Village/Data/PersistentStorage/KeychainError.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/KeychainError.swift
@@ -1,0 +1,27 @@
+//
+//  KeychainError.swift
+//  Village
+//
+//  Created by 정상윤 on 11/29/23.
+//
+
+import Foundation
+
+enum KeychainError: LocalizedError {
+    
+    case duplicate
+    case notFound
+    case unknown(OSStatus)
+    
+    var errorDescription: String {
+        switch self {
+        case .duplicate:
+            "토큰이 이미 키체인에 존재합니다."
+        case .notFound:
+            "키체인에서 토큰을 찾지 못했습니다."
+        case .unknown(let status):
+            "알 수 없는 에러입니다: \(status)"
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
@@ -53,4 +53,15 @@ final class KeychainManager {
         return token
     }
     
+    func delete() throws {
+        let query: [CFString: AnyObject] = [
+            kSecClass: kSecClassGenericPassword
+        ]
+        
+        let status = SecItemDelete(query as CFDictionary)
+        
+        guard status != errSecItemNotFound else { throw KeychainError.notFound }
+        guard status == errSecSuccess else { throw KeychainError.unknown(status) }
+    }
+    
 }

--- a/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
@@ -64,4 +64,23 @@ final class KeychainManager {
         guard status == errSecSuccess else { throw KeychainError.unknown(status) }
     }
     
+    func update(token: AuthenticationToken) throws {
+        do {
+            let data = try JSONEncoder().encode(token)
+            let query: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+            ]
+            let attribute: [CFString: Any] = [
+                kSecAttrAccount: server,
+                kSecValueData: data
+            ]
+            let status = SecItemUpdate(query as CFDictionary, attribute as CFDictionary)
+            
+            guard status != errSecItemNotFound else { throw KeychainError.notFound }
+            guard status == errSecSuccess else { throw KeychainError.unknown(status) }
+        } catch let error {
+            dump(error)
+        }
+    }
+    
 }

--- a/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
@@ -1,0 +1,39 @@
+//
+//  KeychainManager.swift
+//  Village
+//
+//  Created by 정상윤 on 11/29/23.
+//
+
+import Foundation
+import Security
+
+final class KeychainManager {
+    
+    static let shared = KeychainManager()
+    
+    private let server = "https://www.village-api.shop"
+    
+    func write(token: AuthenticationToken) throws {
+        do {
+            let data = try JSONEncoder().encode(token)
+            let query: [CFString: Any] = [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrAccount: server,
+                kSecValueData: data
+            ]
+            
+            let status = SecItemAdd(query as CFDictionary, nil)
+            guard status != errSecDuplicateItem else {
+                throw KeychainError.duplicate
+            }
+            
+            guard status == errSecSuccess else {
+                throw KeychainError.unknown(status)
+            }
+        } catch let error {
+            dump(error)
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
@@ -12,14 +12,12 @@ final class KeychainManager {
     
     static let shared = KeychainManager()
     
-    private let server = "https://www.village-api.shop"
-    
-    func write(token: AuthenticationToken) throws {
+    func write(email: String, token: AuthenticationToken) throws {
         do {
             let data = try JSONEncoder().encode(token)
             let query: [CFString: Any] = [
                 kSecClass: kSecClassGenericPassword,
-                kSecAttrAccount: server,
+                kSecAttrAccount: email,
                 kSecValueData: data
             ]
             
@@ -36,11 +34,12 @@ final class KeychainManager {
         }
     }
     
-    func read() -> AuthenticationToken? {
-        let query: [CFString: AnyObject] = [
+    func read(email: String) -> AuthenticationToken? {
+        let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
-            kSecReturnAttributes: kCFBooleanTrue,
-            kSecReturnData: kCFBooleanTrue,
+            kSecAttrAccount: email,
+            kSecReturnAttributes: true,
+            kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne
         ]
         
@@ -53,9 +52,10 @@ final class KeychainManager {
         return token
     }
     
-    func delete() throws {
-        let query: [CFString: AnyObject] = [
-            kSecClass: kSecClassGenericPassword
+    func delete(email: String) throws {
+        let query: [CFString: Any] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccount: email
         ]
         
         let status = SecItemDelete(query as CFDictionary)
@@ -64,14 +64,14 @@ final class KeychainManager {
         guard status == errSecSuccess else { throw KeychainError.unknown(status) }
     }
     
-    func update(token: AuthenticationToken) throws {
+    func update(email: String, token: AuthenticationToken) throws {
         do {
             let data = try JSONEncoder().encode(token)
             let query: [CFString: Any] = [
                 kSecClass: kSecClassGenericPassword,
             ]
             let attribute: [CFString: Any] = [
-                kSecAttrAccount: server,
+                kSecAttrAccount: email,
                 kSecValueData: data
             ]
             let status = SecItemUpdate(query as CFDictionary, attribute as CFDictionary)

--- a/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
@@ -36,4 +36,21 @@ final class KeychainManager {
         }
     }
     
+    func read() -> AuthenticationToken? {
+        let query: [CFString: AnyObject] = [
+            kSecClass: kSecClassGenericPassword,
+            kSecReturnAttributes: kCFBooleanTrue,
+            kSecReturnData: kCFBooleanTrue,
+            kSecMatchLimit: kSecMatchLimitOne
+        ]
+        
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard let result = result as? [String: AnyObject],
+              let data = result[kSecValueData as String] as? Data,
+              let token = try? JSONDecoder().decode(AuthenticationToken.self, from: data) else { return nil }
+        
+        return token
+    }
+    
 }


### PR DESCRIPTION
## 이슈
- #224 

## 체크리스트
- [x] KeychainManager 클래스 생성
- [x] read
- [x] write
- [x] delete
- [x] update

## 고민한 내용
- 키체인을 다루는게 처음이라 검색과 학습을 병행하면서 구현했습니다.
- 한 기기에 한 사용자의 토큰만 저장된다는 전제로 구현했다가, 다양한 계정에 대한 키체인이 다뤄지도록 애플 계정의 email을 쿼리의 `kSecAttrAccount`에 할당하도록 코드를 수정했습니다.

## 스크린샷
없음