### PR TITLE
[iOS/#228] 마이페이지 뷰 구현 및 AutoLayout 적용

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		59AABDE12B0E1BB8002F6D0E /* PostCreatePriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */; };
 		59AABDE32B0E272C002F6D0E /* PostCreateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */; };
 		59AABDE52B0E2D47002F6D0E /* PostCreateDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */; };
+		59B6E2732B17938C000864F9 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B6E2722B17938C000864F9 /* MyPageViewModel.swift */; };
 		59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59BD5DC82B0C760500FEB80F /* UIStackView+.swift */; };
 		59BD5DCC2B0C772200FEB80F /* PostCreateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E196C82B045F4900BF7C5A /* PostCreateViewController.swift */; };
 		59BD5DCE2B0C775D00FEB80F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0C5FD2AFBA3FC0073D494 /* SceneDelegate.swift */; };
@@ -138,6 +139,7 @@
 		59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreatePriceView.swift; sourceTree = "<group>"; };
 		59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateTimeView.swift; sourceTree = "<group>"; };
 		59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateDetailView.swift; sourceTree = "<group>"; };
+		59B6E2722B17938C000864F9 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		59BD5DC82B0C760500FEB80F /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		59D4DBDD2B06889300BBA2D5 /* TimePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePickerView.swift; sourceTree = "<group>"; };
 		59D4DBE12B068C6400BBA2D5 /* UIView+Layer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Layer.swift"; sourceTree = "<group>"; };
@@ -349,6 +351,22 @@
 			children = (
 			);
 			path = VillageTests;
+			sourceTree = "<group>";
+		};
+		59B6E26F2B17931F000864F9 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				8FD52A472B09D1AD005EE367 /* MyPageViewController.swift */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		59B6E2712B179384000864F9 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				59B6E2722B17938C000864F9 /* MyPageViewModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		59BD5DD02B0C785900FEB80F /* View */ = {
@@ -621,7 +639,8 @@
 		8FD52A462B09D1AD005EE367 /* MyPage */ = {
 			isa = PBXGroup;
 			children = (
-				8FD52A472B09D1AD005EE367 /* MyPageViewController.swift */,
+				59B6E2712B179384000864F9 /* ViewModel */,
+				59B6E26F2B17931F000864F9 /* View */,
 			);
 			name = MyPage;
 			path = Village/Presentation/MyPage;
@@ -807,11 +826,11 @@
 			files = (
 				4416D4502B14A4420052BF33 /* SignUpViewController.swift in Sources */,
 				59110EFD2B15F5340009E9AC /* UITableViewCell+Identifier.swift in Sources */,
-				44C1F5DF2B0FA8400047A436 /* Assets.xcassets in Sources */,
 				59BD5DCE2B0C775D00FEB80F /* SceneDelegate.swift in Sources */,
 				4416D4862B171CE50052BF33 /* AppleOAuthDTO.swift in Sources */,
 				59BD5DCC2B0C772200FEB80F /* PostCreateViewController.swift in Sources */,
 				4416D4532B14AB300052BF33 /* ProfileImageView.swift in Sources */,
+				59B6E2732B17938C000864F9 /* MyPageViewModel.swift in Sources */,
 				8F1B53322B0DE0D8006D8982 /* APIEndPoints.swift in Sources */,
 				4416D4832B171C730052BF33 /* AuthenticationToken.swift in Sources */,
 				59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */,
@@ -931,6 +950,15 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Village.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Village";
+			};
+			name = Release;
+		};
+		59B6E2702B17931F000864F9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				PRODUCT_NAME = Village;
 			};
 			name = Release;
 		};
@@ -1106,7 +1134,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				59E0C60D2AFBA3FE0073D494 /* Debug */,
-				59E0C60E2AFBA3FE0073D494 /* Release */,
+				59B6E2702B17931F000864F9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iOS/Village/Village/Application/AppTabBarController.swift
+++ b/iOS/Village/Village/Application/AppTabBarController.swift
@@ -21,14 +21,27 @@ final class AppTabBarController: UITabBarController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        tabBar.tintColor = .primary500
-        tabBar.unselectedItemTintColor = .primary500
+        setup()
         setViewControllers()
         configureTabBarItems()
     }
     
+    // TODO: shadow 
+    private func setup() {
+        view.backgroundColor = .systemBackground
+        tabBar.isTranslucent = false
+        tabBar.backgroundColor = .systemBackground
+        tabBar.tintColor = .primary500
+        tabBar.unselectedItemTintColor = .primary500
+    }
+    
     private func setViewControllers() {
+        homeViewController.navigationBar.isTranslucent = false
+        homeViewController.navigationBar.backgroundColor = .systemBackground
+        chatListViewController.navigationBar.isTranslucent = false
+        chatListViewController.navigationBar.backgroundColor = .systemBackground
+        myPageViewController.navigationBar.isTranslucent = false
+        myPageViewController.navigationBar.backgroundColor = .systemBackground
         setViewControllers(
             [homeViewController, chatListViewController, myPageViewController],
             animated: true

--- a/iOS/Village/Village/Application/AppTabBarController.swift
+++ b/iOS/Village/Village/Application/AppTabBarController.swift
@@ -9,9 +9,15 @@ import UIKit
 
 final class AppTabBarController: UITabBarController {
     
-    private let homeViewController = UINavigationController(rootViewController: HomeViewController())
-    private let chatListViewController = UINavigationController(rootViewController: ChatListViewController())
-    private let myPageViewController = UINavigationController(rootViewController: MyPageViewController())
+    private let homeViewController = UINavigationController(
+        rootViewController: HomeViewController()
+    )
+    private let chatListViewController = UINavigationController(
+        rootViewController: ChatListViewController()
+    )
+    private let myPageViewController = UINavigationController(
+        rootViewController: MyPageViewController(viewModel: MyPageViewModel())
+    )
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/iOS/Village/Village/Data/Dummy/ChatList.json
+++ b/iOS/Village/Village/Data/Dummy/ChatList.json
@@ -3,6 +3,57 @@
         "user":"조성민", "user_profile":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png", "recent_time": "2023-11-21T12:34:56", "recent_chat":"안녕하세요", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
     },
     {
-        "user":"dlwlrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+        "user":"dlwl1rma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlwl2rma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlw3lrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlw4lrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlw44lrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlw5lrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlwlr66ma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlwlr123123ma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlw7lrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlwl10023rma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlw131lrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlw112lrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlw331lrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlwlr098ma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlwlr07ma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlwl421rma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlw55lrma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
+    },
+    {
+        "user":"dlwl75rma", "user_profile":"https://img.gqkorea.co.kr/gq/2022/08/style_63073140eea70.jpg", "recent_time": "2023-11-24T00:34:56", "recent_chat":"안녕하세요!!", "post_image":"https://cdn-icons-png.flaticon.com/512/12719/12719172.png"
     }
 ]

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -39,6 +39,7 @@ final class ChatRoomViewController: UIViewController {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 80
         tableView.register(ChatRoomTableViewCell.self, forCellReuseIdentifier: reuseIdentifier)
+        tableView.separatorStyle = .none
         
         return tableView
     }()

--- a/iOS/Village/Village/Presentation/ChatRoom/View/CustomView/PostView.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/CustomView/PostView.swift
@@ -45,6 +45,7 @@ final class PostView: UIView {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.image = UIImage(systemName: ImageSystemName.chevronRight.rawValue)
+        imageView.tintColor = .primary500
         
         return imageView
     }()

--- a/iOS/Village/Village/Presentation/Commons/PostSummaryView.swift
+++ b/iOS/Village/Village/Presentation/Commons/PostSummaryView.swift
@@ -45,6 +45,7 @@ final class PostSummaryView: UIView {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.image = UIImage(systemName: ImageSystemName.chevronRight.rawValue)
+        imageView.tintColor = .primary500
         
         return imageView
     }()

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class MyPageViewController: UIViewController {
+final class MyPageViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -16,7 +16,10 @@ final class MyPageViewController: UIViewController {
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.image = UIImage(systemName: ImageSystemName.person.rawValue)
+        imageView.image = UIImage(systemName: ImageSystemName.personFill.rawValue)
+        imageView.tintColor = .primary500
+        imageView.setLayer(borderWidth: 0, cornerRadius: 16)
+        imageView.backgroundColor = .primary100
         
         return imageView
     }()
@@ -51,7 +54,8 @@ final class MyPageViewController: UIViewController {
         button.addTarget(self, action: #selector(profileEditButtonTapped), for: .touchUpInside)
         button.configuration = configuration
         button.contentHorizontalAlignment = .leading
-        button.setLayer()
+        button.setLayer(borderWidth: 0)
+        button.backgroundColor = .systemGray5
         
         return button
     }()
@@ -70,18 +74,19 @@ final class MyPageViewController: UIViewController {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
-        stackView.spacing = 15
+        stackView.spacing = 10
         
         return stackView
     }()
     
     private lazy var myPostButton: UIButton = {
         var titleAttr = AttributedString.init("내 게시글")
-        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        titleAttr.font = .systemFont(ofSize: 16, weight: .bold)
         
         var configuration = UIButton.Configuration.plain()
         configuration.baseForegroundColor = .label
         configuration.attributedTitle = titleAttr
+        configuration.buttonSize = .medium
         
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -94,11 +99,12 @@ final class MyPageViewController: UIViewController {
     
     private lazy var hiddenPostButton: UIButton = {
         var titleAttr = AttributedString.init("숨긴 게시글")
-        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        titleAttr.font = .systemFont(ofSize: 16, weight: .bold)
         
         var configuration = UIButton.Configuration.plain()
         configuration.baseForegroundColor = .label
         configuration.attributedTitle = titleAttr
+        configuration.buttonSize = .medium
         
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -111,11 +117,12 @@ final class MyPageViewController: UIViewController {
     
     private lazy var hiddenUserButton: UIButton = {
         var titleAttr = AttributedString.init("차단 관리")
-        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        titleAttr.font = .systemFont(ofSize: 16, weight: .bold)
         
         var configuration = UIButton.Configuration.plain()
         configuration.baseForegroundColor = .label
         configuration.attributedTitle = titleAttr
+        configuration.buttonSize = .medium
         
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -138,11 +145,12 @@ final class MyPageViewController: UIViewController {
     
     private lazy var logoutButton: UIButton = {
         var titleAttr = AttributedString.init("로그아웃")
-        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        titleAttr.font = .systemFont(ofSize: 16, weight: .bold)
         
         var configuration = UIButton.Configuration.plain()
         configuration.baseForegroundColor = .label
         configuration.attributedTitle = titleAttr
+        configuration.buttonSize = .medium
         
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -155,11 +163,12 @@ final class MyPageViewController: UIViewController {
     
     private lazy var deleteAccountButton: UIButton = {
         var titleAttr = AttributedString.init("회원탈퇴")
-        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        titleAttr.font = .systemFont(ofSize: 16, weight: .bold)
         
         var configuration = UIButton.Configuration.plain()
         configuration.baseForegroundColor = .label
         configuration.attributedTitle = titleAttr
+        configuration.buttonSize = .medium
         
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -174,7 +183,7 @@ final class MyPageViewController: UIViewController {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
-        stackView.spacing = 15
+        stackView.spacing = 10
         
         return stackView
     }()
@@ -219,14 +228,11 @@ private extension MyPageViewController {
         
         activityStackView.addArrangedSubview(activityLabel)
         activityStackView.addArrangedSubview(myPostButton)
-        activityStackView.addArrangedSubview(UIView.divider(.horizontal))
         activityStackView.addArrangedSubview(hiddenPostButton)
-        activityStackView.addArrangedSubview(UIView.divider(.horizontal))
         activityStackView.addArrangedSubview(hiddenUserButton)
         
         accountStackView.addArrangedSubview(accountLabel)
         accountStackView.addArrangedSubview(logoutButton)
-        accountStackView.addArrangedSubview(UIView.divider(.horizontal))
         accountStackView.addArrangedSubview(deleteAccountButton)
         
     }
@@ -257,13 +263,13 @@ private extension MyPageViewController {
         
         NSLayoutConstraint.activate([
             activityStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            activityStackView.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: 16),
+            activityStackView.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: 35),
             activityStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
         ])
         
         NSLayoutConstraint.activate([
             accountStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
-            accountStackView.topAnchor.constraint(equalTo: activityStackView.bottomAnchor, constant: 25),
+            accountStackView.topAnchor.constraint(equalTo: activityStackView.bottomAnchor, constant: 40),
             accountStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
         ])
 

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -6,13 +6,300 @@
 //
 
 import UIKit
+import Combine
 
 final class MyPageViewController: UIViewController {
+    
+    private let viewModel: MyPageViewModel
+    private var cancellableBag: Set<AnyCancellable> = []
+    
+    private let profileImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = UIImage(systemName: ImageSystemName.person.rawValue)
+        
+        return imageView
+    }()
+    
+    private let nicknameLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        label.text = "닉네임"
+        
+        return label
+    }()
+    
+    private let hashIDLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.systemFont(ofSize: 16)
+        label.text = "#123123"
+        label.textColor = .secondaryLabel
+        
+        return label
+    }()
+    
+    private lazy var profileEditButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = "프로필 수정"
+        configuration.titleAlignment = .center
+        configuration.baseForegroundColor = .label
+        
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(profileEditButtonTapped), for: .touchUpInside)
+        button.configuration = configuration
+        button.contentHorizontalAlignment = .leading
+        button.setLayer()
+        
+        return button
+    }()
+    
+    private let activityLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "내 활동"
+        label.textColor = .secondaryLabel
+        label.font = .boldSystemFont(ofSize: 14)
+        
+        return label
+    }()
+    
+    private let activityStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 15
+        
+        return stackView
+    }()
+    
+    private lazy var myPostButton: UIButton = {
+        var titleAttr = AttributedString.init("내 게시글")
+        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .label
+        configuration.attributedTitle = titleAttr
+        
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(myPostButtonTapped), for: .touchUpInside)
+        button.configuration = configuration
+        button.contentHorizontalAlignment = .leading
 
+        return button
+    }()
+    
+    private lazy var hiddenPostButton: UIButton = {
+        var titleAttr = AttributedString.init("숨긴 게시글")
+        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .label
+        configuration.attributedTitle = titleAttr
+        
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(hiddenPostButtonTapped), for: .touchUpInside)
+        button.configuration = configuration
+        button.contentHorizontalAlignment = .leading
+        
+        return button
+    }()
+    
+    private lazy var hiddenUserButton: UIButton = {
+        var titleAttr = AttributedString.init("차단 관리")
+        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .label
+        configuration.attributedTitle = titleAttr
+        
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(hiddenUserButtonTapped), for: .touchUpInside)
+        button.configuration = configuration
+        button.contentHorizontalAlignment = .leading
+        
+        return button
+    }()
+    
+    private let accountLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "계정"
+        label.textColor = .secondaryLabel
+        label.font = .boldSystemFont(ofSize: 14)
+        
+        return label
+    }()
+    
+    private lazy var logoutButton: UIButton = {
+        var titleAttr = AttributedString.init("로그아웃")
+        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .label
+        configuration.attributedTitle = titleAttr
+        
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(logoutButtonTapped), for: .touchUpInside)
+        button.configuration = configuration
+        button.contentHorizontalAlignment = .leading
+        
+        return button
+    }()
+    
+    private lazy var deleteAccountButton: UIButton = {
+        var titleAttr = AttributedString.init("회원탈퇴")
+        titleAttr.font = .systemFont(ofSize: 18, weight: .bold)
+        
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .label
+        configuration.attributedTitle = titleAttr
+        
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(deleteAccountButtonTapped), for: .touchUpInside)
+        button.configuration = configuration
+        button.contentHorizontalAlignment = .leading
+        
+        return button
+    }()
+    
+    private let accountStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 15
+        
+        return stackView
+    }()
+    
+    init(viewModel: MyPageViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        setNavigationUI()
+        setUI()
+        setConstraints()
+        bindViewModel()
         view.backgroundColor = .systemBackground
+    }
+    
+}
+
+private extension MyPageViewController {
+    
+    func setNavigationUI() {
+        let titleLabel = UILabel()
+        titleLabel.setTitle("마이페이지")
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: titleLabel)
+        self.navigationItem.backButtonDisplayMode = .minimal
+    }
+    
+    func setUI() {
+        view.addSubview(profileImageView)
+        view.addSubview(nicknameLabel)
+        view.addSubview(hashIDLabel)
+        view.addSubview(profileEditButton)
+        view.addSubview(activityStackView)
+        view.addSubview(accountStackView)
+        
+        activityStackView.addArrangedSubview(activityLabel)
+        activityStackView.addArrangedSubview(myPostButton)
+        activityStackView.addArrangedSubview(UIView.divider(.horizontal))
+        activityStackView.addArrangedSubview(hiddenPostButton)
+        activityStackView.addArrangedSubview(UIView.divider(.horizontal))
+        activityStackView.addArrangedSubview(hiddenUserButton)
+        
+        accountStackView.addArrangedSubview(accountLabel)
+        accountStackView.addArrangedSubview(logoutButton)
+        accountStackView.addArrangedSubview(UIView.divider(.horizontal))
+        accountStackView.addArrangedSubview(deleteAccountButton)
+        
+    }
+    
+    func setConstraints() {
+                
+        NSLayoutConstraint.activate([
+            profileImageView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            profileImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 6),
+            profileImageView.widthAnchor.constraint(equalToConstant: 96),
+            profileImageView.heightAnchor.constraint(equalToConstant: 96)
+        ])
+        
+        NSLayoutConstraint.activate([
+            nicknameLabel.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: 15),
+            nicknameLabel.bottomAnchor.constraint(equalTo: profileImageView.centerYAnchor, constant: -5)
+        ])
+        
+        NSLayoutConstraint.activate([
+            hashIDLabel.leadingAnchor.constraint(equalTo: nicknameLabel.trailingAnchor, constant: 5),
+            hashIDLabel.bottomAnchor.constraint(equalTo: nicknameLabel.bottomAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            profileEditButton.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: 15),
+            profileEditButton.topAnchor.constraint(equalTo: profileImageView.centerYAnchor, constant: 5)
+        ])
+        
+        NSLayoutConstraint.activate([
+            activityStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            activityStackView.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: 16),
+            activityStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
+        ])
+        
+        NSLayoutConstraint.activate([
+            accountStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            accountStackView.topAnchor.constraint(equalTo: activityStackView.bottomAnchor, constant: 25),
+            accountStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)
+        ])
+
+    }
+    
+    func bindViewModel() {
+        
+    }
+    
+}
+
+@objc
+private extension MyPageViewController {
+    
+    func profileEditButtonTapped() {
+        
+    }
+    
+    func myPostButtonTapped() {
+        
+    }
+    
+    func hiddenPostButtonTapped() {
+        
+    }
+    
+    func hiddenUserButtonTapped() {
+        
+    }
+    
+    func logoutButtonTapped() {
+        
+    }
+    
+    func deleteAccountButtonTapped() {
+        
     }
     
 }

--- a/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  MyPageViewModel.swift
+//  Village
+//
+//  Created by 조성민 on 11/30/23.
+//
+
+import Foundation
+
+final class MyPageViewModel {
+    
+}


### PR DESCRIPTION
## 이슈
- #228 

## 체크리스트
- [x] Figma 디자인에 맞게 마이페이지의 UI를 구현한다.

## 고민한 내용
- 마이페이지 레이아웃을 StackView로 잡았습니다. 추후에 요소가 많아질 경우 UITableView로 바꾸는 것을 고려해봐야할 것 같습니다.
- 네비게이션바와 탭바가 블러처리가 되는 현상이 있었습니다. 그래서 isTranslucent = false로 고쳤습니다.
- 채팅룸에서 채팅 cell끼리 sperator가 있는 것을 고쳤습니다.
- PrimaryColor를 지정하지 않은 ImageView가 있어서 수정했습니다. 

## 스크린샷
|다크모드 X|다크모드 O|
| --- | --- |
| <img width="599" alt="image" src="https://github.com/boostcampwm2023/iOS05-Village/assets/128480641/eaeb5e1f-1e54-432f-99ef-89629a02eb3b"> | <img width="599" alt="image" src="https://github.com/boostcampwm2023/iOS05-Village/assets/128480641/e70e8ab3-b279-493b-92c8-fdb6ad359fac"> |
 
