### PR TITLE
[iOS/#226] 자동 로그인 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		444A50942B0C8D1900454397 /* UIView+Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444A50932B0C8D1900454397 /* UIView+Divider.swift */; };
 		444A50982B0CE25200454397 /* DurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444A50972B0CE25200454397 /* DurationView.swift */; };
 		444A509A2B0CE94E00454397 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444A50992B0CE94E00454397 /* DateView.swift */; };
+		4461F39D2B1786DA00723C55 /* JWTManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4461F39C2B1786DA00723C55 /* JWTManager.swift */; };
 		446362C92B0DF9E800B74DA7 /* PriceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446362C82B0DF9E800B74DA7 /* PriceLabel.swift */; };
 		446362CB2B0DFD4F00B74DA7 /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446362CA2B0DFD4F00B74DA7 /* Int+.swift */; };
 		446362CF2B0F042500B74DA7 /* PostInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446362CE2B0F042500B74DA7 /* PostInfoView.swift */; };
@@ -115,6 +116,7 @@
 		444A50932B0C8D1900454397 /* UIView+Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Divider.swift"; sourceTree = "<group>"; };
 		444A50972B0CE25200454397 /* DurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationView.swift; sourceTree = "<group>"; };
 		444A50992B0CE94E00454397 /* DateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
+		4461F39C2B1786DA00723C55 /* JWTManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTManager.swift; sourceTree = "<group>"; };
 		446362C82B0DF9E800B74DA7 /* PriceLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceLabel.swift; sourceTree = "<group>"; };
 		446362CA2B0DFD4F00B74DA7 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		446362CE2B0F042500B74DA7 /* PostInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostInfoView.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 			children = (
 				4416D48D2B174CBA0052BF33 /* KeychainError.swift */,
 				4416D48B2B174C7A0052BF33 /* KeychainManager.swift */,
+				4461F39C2B1786DA00723C55 /* JWTManager.swift */,
 			);
 			path = PersistentStorage;
 			sourceTree = "<group>";
@@ -833,6 +836,7 @@
 				446362CF2B0F042500B74DA7 /* PostInfoView.swift in Sources */,
 				8FBE3B0A2B0478D400660530 /* HomeCollectionViewCell.swift in Sources */,
 				59AABDE52B0E2D47002F6D0E /* PostCreateDetailView.swift in Sources */,
+				4461F39D2B1786DA00723C55 /* JWTManager.swift in Sources */,
 				440FCC2D2B04EB940011B637 /* Constants.swift in Sources */,
 				8F3D79E62B1469DF00370536 /* UICollectionViewCell+Identifier.swift in Sources */,
 				444A50982B0CE25200454397 /* DurationView.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -810,7 +810,6 @@
 			files = (
 				4416D4502B14A4420052BF33 /* SignUpViewController.swift in Sources */,
 				59110EFD2B15F5340009E9AC /* UITableViewCell+Identifier.swift in Sources */,
-				44C1F5DF2B0FA8400047A436 /* Assets.xcassets in Sources */,
 				59BD5DCE2B0C775D00FEB80F /* SceneDelegate.swift in Sources */,
 				4416D4862B171CE50052BF33 /* AppleOAuthDTO.swift in Sources */,
 				59BD5DCC2B0C772200FEB80F /* PostCreateViewController.swift in Sources */,
@@ -894,6 +893,15 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		4461F39B2B177B8000723C55 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				PRODUCT_NAME = Village;
+			};
+			name = Release;
+		};
 		59AA12A02B03726C00AFC766 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1110,7 +1118,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				59E0C60D2AFBA3FE0073D494 /* Debug */,
-				59E0C60E2AFBA3FE0073D494 /* Release */,
+				4461F39B2B177B8000723C55 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iOS/Village/Village/Application/SceneDelegate.swift
+++ b/iOS/Village/Village/Application/SceneDelegate.swift
@@ -14,11 +14,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
-        observeLoginSucceedEvent()
+        addObservers()
         
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = LoginViewController()
+        autoLogin()
         window?.makeKeyAndVisible()
+    }
+    
+    private func addObservers() {
+        observeLoginSucceedEvent()
+        observeShouldLoginEvent()
     }
     
     private func observeLoginSucceedEvent() {
@@ -29,9 +34,69 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         )
     }
     
+    private func observeShouldLoginEvent() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(rootViewControllerToLoginViewController),
+                                               name: .shouldLogin,
+                                               object: nil)
+    }
+    
+    private func autoLogin() {
+        guard let token = JWTManager.shared.get() else { return }
+        let endpoint = APIEndPoints.tokenExpire(accessToken: token.refreshToken)
+        Task {
+            do {
+                try await APIProvider.shared.request(with: endpoint)
+                window?.rootViewController = AppTabBarController()
+            } catch let error {
+                if let err = error as? NetworkError {
+                    switch err {
+                    case .serverError(.forbidden):
+                        dump("forbidden came!")
+                        refreshToken()
+                    case .serverError(.serverError):
+                        dump("서버 에러가 발생했습니다! 다시 로그인해주세요.")
+                    default:
+                        dump(error)
+                    }
+                }
+                window?.rootViewController = LoginViewController()
+                return
+            }
+        }
+    }
+    
+    private func refreshToken() {
+        guard let refreshToken = JWTManager.shared.get()?.refreshToken else { return }
+        
+        let endpoint = APIEndPoints.tokenRefresh(refreshToken: refreshToken)
+        Task {
+            do {
+                guard let token = try await APIProvider.shared.request(with: endpoint) else { return }
+                try JWTManager.shared.update(token: token)
+                window?.rootViewController = AppTabBarController()
+            } catch let error {
+                if let err = error as? NetworkError {
+                    switch err {
+                    case .serverError(.forbidden):
+                        dump("토큰이 만료됐습니다! 다시 로그인해주세요.")
+                        NotificationCenter.default.post(Notification(name: .shouldLogin))
+                    default:
+                        dump(error)
+                    }
+                }
+            }
+        }
+    }
+    
     @objc
     private func rootViewControllerToTabBarController() {
         window?.rootViewController = AppTabBarController()
+    }
+    
+    @objc
+    private func rootViewControllerToLoginViewController() {
+        window?.rootViewController = LoginViewController()
     }
 
 }

--- a/iOS/Village/Village/Application/SceneDelegate.swift
+++ b/iOS/Village/Village/Application/SceneDelegate.swift
@@ -14,17 +14,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
+        observeLoginSucceedEvent()
+        
         window = UIWindow(windowScene: windowScene)
         window?.rootViewController = LoginViewController()
         window?.makeKeyAndVisible()
-        
-        observeLoginSucceedEvent()
     }
     
     private func observeLoginSucceedEvent() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(rootViewControllerToTabBarController),
-                                               name: Notification.Name("LoginSucceed"),
+                                               name: .loginSucceed,
                                                object: nil
         )
     }

--- a/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
@@ -27,6 +27,10 @@ final class JWTManager {
         
         do {
             try KeychainManager.shared.write(email: email, token: token)
+        } catch let error as KeychainError {
+            if case .duplicate = error {
+                try? KeychainManager.shared.update(email: email, token: token)
+            }
         } catch let error {
             dump(error)
         }

--- a/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
@@ -1,0 +1,55 @@
+//
+//  JWTManager.swift
+//  Village
+//
+//  Created by 정상윤 on 11/29/23.
+//
+
+import Foundation
+
+final class JWTManager {
+    
+    static let shared = JWTManager()
+    
+    private let lastLoggedEmailKey = "lastLoggedEmail"
+    private var userEmail: String? {
+        UserDefaults.standard.string(forKey: lastLoggedEmailKey)
+    }
+    
+    func get() -> AuthenticationToken? {
+        guard let email = userEmail else { return nil }
+        
+        return KeychainManager.shared.read(email: email)
+    }
+    
+    func save(email: String, token: AuthenticationToken) {
+        UserDefaults.standard.setValue(email, forKey: lastLoggedEmailKey)
+        
+        do {
+            try KeychainManager.shared.write(email: email, token: token)
+        } catch let error {
+            dump(error)
+        }
+    }
+    
+    func delete() throws {
+        guard let email = userEmail else { return }
+        
+        do {
+            try KeychainManager.shared.delete(email: email)
+        } catch let error {
+            dump(error)
+        }
+    }
+    
+    func update(token: AuthenticationToken) throws {
+        guard let email = userEmail else { return }
+        
+        do {
+            try KeychainManager.shared.update(email: email, token: token)
+        } catch let error {
+            dump(error)
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
@@ -44,7 +44,7 @@ final class KeychainManager {
         ]
         
         var result: CFTypeRef?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        SecItemCopyMatching(query as CFDictionary, &result)
         guard let result = result as? [String: AnyObject],
               let data = result[kSecValueData as String] as? Data,
               let token = try? JSONDecoder().decode(AuthenticationToken.self, from: data) else { return nil }
@@ -68,7 +68,7 @@ final class KeychainManager {
         do {
             let data = try JSONEncoder().encode(token)
             let query: [CFString: Any] = [
-                kSecClass: kSecClassGenericPassword,
+                kSecClass: kSecClassGenericPassword
             ]
             let attribute: [CFString: Any] = [
                 kSecAttrAccount: email,

--- a/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/KeychainManager.swift
@@ -29,8 +29,6 @@ final class KeychainManager {
             guard status == errSecSuccess else {
                 throw KeychainError.unknown(status)
             }
-        } catch let error {
-            dump(error)
         }
     }
     
@@ -68,18 +66,16 @@ final class KeychainManager {
         do {
             let data = try JSONEncoder().encode(token)
             let query: [CFString: Any] = [
-                kSecClass: kSecClassGenericPassword
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrAccount: email
             ]
             let attribute: [CFString: Any] = [
-                kSecAttrAccount: email,
                 kSecValueData: data
             ]
             let status = SecItemUpdate(query as CFDictionary, attribute as CFDictionary)
             
             guard status != errSecItemNotFound else { throw KeychainError.notFound }
             guard status == errSecSuccess else { throw KeychainError.unknown(status) }
-        } catch let error {
-            dump(error)
         }
     }
     

--- a/iOS/Village/Village/Network/APIProvider/APIProvider.swift
+++ b/iOS/Village/Village/Network/APIProvider/APIProvider.swift
@@ -33,6 +33,13 @@ final class APIProvider: Provider {
         return try self.decode(data)
     }
     
+    func request<E: Requestable&Responsable>(with endpoint: E) async throws {
+        let urlRequest = try endpoint.makeURLRequest()
+        let (_, response) = try await session.data(for: urlRequest)
+        
+        try self.checkStatusCode(response)
+    }
+    
     func request(from url: String) async throws -> Data {
         guard let url = URL(string: url) else { throw NetworkError.urlRequestError }
         let (data, response) = try await session.data(from: url)

--- a/iOS/Village/Village/Presentation/Login/LoginViewController.swift
+++ b/iOS/Village/Village/Presentation/Login/LoginViewController.swift
@@ -84,7 +84,7 @@ final class LoginViewController: UIViewController {
     }
     
     private func notifyLoginSucceed() {
-        NotificationCenter.default.post(Notification(name: Notification.Name("LoginSucceed")))
+        NotificationCenter.default.post(Notification(name: .loginSucceed))
     }
 
 }

--- a/iOS/Village/Village/Presentation/Login/LoginViewController.swift
+++ b/iOS/Village/Village/Presentation/Login/LoginViewController.swift
@@ -44,14 +44,6 @@ final class LoginViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        if viewModel.autoLogin() {
-            notifyLoginSucceed()
-        }
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         
         configureUI()
         setLayoutConstraints()
@@ -61,19 +53,17 @@ final class LoginViewController: UIViewController {
     private func bindViewModel() {
         viewModel.transform(input: Input(identityToken: identityToken.eraseToAnyPublisher(),
                                          authorizationCode: authorizationCode.eraseToAnyPublisher()))
-        .authenticationToken
-        .receive(on: DispatchQueue.main)
-        .sink(receiveCompletion: { completion in
-            switch completion {
-            case .failure(let error):
-                dump(error)
-            default:
-                break
-            }
-        }, receiveValue: { [weak self] _ in
-            self?.notifyLoginSucceed()
-        })
-        .store(in: &cancellableBag)
+            .loginSucceed
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .failure(let error):
+                    dump(error)
+                default:
+                    break
+                }
+            }, receiveValue: { self.notifyLoginSucceed() })
+            .store(in: &cancellableBag)
     }
     
     @objc

--- a/iOS/Village/Village/Presentation/Login/LoginViewController.swift
+++ b/iOS/Village/Village/Presentation/Login/LoginViewController.swift
@@ -45,6 +45,14 @@ final class LoginViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        if viewModel.autoLogin() {
+            notifyLoginSucceed()
+        }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
         configureUI()
         setLayoutConstraints()
         bindViewModel()

--- a/iOS/Village/Village/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/iOS/Village/Village/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -17,22 +17,31 @@ final class LoginViewModel {
         Publishers.Zip(input.identityToken, input.authorizationCode)
             .sink(receiveValue: { [weak self] (token, code) in
                 guard let tokenString = String(data: token, encoding: .utf8),
-                      let codeString = String(data: code, encoding: .utf8) else { return }
+                      let codeString = String(data: code, encoding: .utf8),
+                      let email = tokenString.decode()["email"] as? String else { return }
                 
-                self?.handleLoginRequest(dto: AppleOAuthDTO(identityToken: tokenString, authorizationCode: codeString))
+                let dto = AppleOAuthDTO(identityToken: tokenString, authorizationCode: codeString)
+                self?.handleLoginRequest(email: email, dto: dto)
             })
             .store(in: &cancellableBag)
         
         return Output(authenticationToken: authenticationToken.eraseToAnyPublisher())
     }
     
-    private func handleLoginRequest(dto: AppleOAuthDTO) {
-        // TODO: 키체인에 저장된 토큰이 있는지 확인 후 서버 요청하도록 구현
+    func autoLogin() -> Bool {
+        guard let token = JWTManager.shared.get() else { return false }
+        
+        return true
+    }
+    
+    private func handleLoginRequest(email: String, dto: AppleOAuthDTO) {
         let endpoint = APIEndPoints.loginAppleOAuth(with: dto)
         Task {
             do {
-                guard let responseToken = try await APIProvider.shared.request(with: endpoint) else { return }
-                authenticationToken.send(responseToken)
+                guard let token = try await APIProvider.shared.request(with: endpoint) else { return }
+                
+                JWTManager.shared.save(email: email, token: token)
+                authenticationToken.send(token)
             } catch let error {
                 authenticationToken.send(completion: .failure(error))
             }

--- a/iOS/Village/Village/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/iOS/Village/Village/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -53,3 +53,34 @@ extension LoginViewModel {
     }
     
 }
+
+fileprivate extension String {
+    
+    func base64UrlDecode(_ value: String) -> Data? {
+        var base64 = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
+        let requiredLength = 4 * ceil(length / 4.0)
+        let paddingLength = requiredLength - length
+        if paddingLength > 0 {
+            let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
+            base64 += padding
+        }
+        return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+    }
+    
+    func decodeJWTPart(_ value: String) -> [String: Any]? {
+        guard let bodyData = base64UrlDecode(value),
+              let json = try? JSONSerialization.jsonObject(with: bodyData, options: []),
+              let payload = json as? [String: Any] else { return nil }
+        return payload
+    }
+    
+    func decode() -> [String: Any] {
+        let segments = self.components(separatedBy: ".")
+        return decodeJWTPart(segments[1]) ?? [:]
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/Utils/Extensions/NotificationName+.swift
+++ b/iOS/Village/Village/Presentation/Utils/Extensions/NotificationName+.swift
@@ -10,4 +10,5 @@ import Foundation
 extension Notification.Name {
     static let openChatRoom = Notification.Name("OpenChatRoom")
     static let loginSucceed = Notification.Name("LoginSucceed")
+    static let shouldLogin = Notification.Name("ShouldLogin")
 }

--- a/iOS/Village/Village/Presentation/Utils/Extensions/NotificationName+.swift
+++ b/iOS/Village/Village/Presentation/Utils/Extensions/NotificationName+.swift
@@ -9,4 +9,5 @@ import Foundation
 
 extension Notification.Name {
     static let openChatRoom = Notification.Name("OpenChatRoom")
+    static let loginSucceed = Notification.Name("LoginSucceed")
 }


### PR DESCRIPTION
## 이슈
- #226 

## 체크리스트
- [x] JWTManager 구현
- [x] 모든 API 요청에 AccessToken 헤더에 넣도록 구현
- [x] Access Token 만료 시 Refresh 요청

## 고민한 내용
- 로그인 관련 로직들을 담당하는 별도의 객체를 또 구현하는게 좋을지 고민입니다. 로그인 로직은 모든 뷰에서 전반적으로 필요할 것 같기 때문입니다.
- SceneDelegate에서 자동 로그인 로직을 현재 처리하고 있습니다. 성공 유무에 따라 Root View Controller를 다르게 설정하고 있는데, 이 부분이 매끄럽지 않은 것 같습니다. 
 Access Token을 Refresh할 때 로그인 화면이 한번 떴다가 홈 화면으로 넘어가는 것 같습니다. 이 부분은 개선하도록 하겠습니다.

## 스크린샷
없음