### PR TITLE
[iOS/#232] 푸시 알림 Firebase 설정

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		59AABDE32B0E272C002F6D0E /* PostCreateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */; };
 		59AABDE52B0E2D47002F6D0E /* PostCreateDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */; };
 		59B6E2732B17938C000864F9 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B6E2722B17938C000864F9 /* MyPageViewModel.swift */; };
+		59B6E27C2B185FD2000864F9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 59B6E27B2B185FD2000864F9 /* GoogleService-Info.plist */; };
+		59B6E27F2B18604D000864F9 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 59B6E27E2B18604D000864F9 /* FirebaseAnalytics */; };
 		59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59BD5DC82B0C760500FEB80F /* UIStackView+.swift */; };
 		59BD5DCC2B0C772200FEB80F /* PostCreateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E196C82B045F4900BF7C5A /* PostCreateViewController.swift */; };
 		59BD5DCE2B0C775D00FEB80F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0C5FD2AFBA3FC0073D494 /* SceneDelegate.swift */; };
@@ -140,6 +142,7 @@
 		59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateTimeView.swift; sourceTree = "<group>"; };
 		59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateDetailView.swift; sourceTree = "<group>"; };
 		59B6E2722B17938C000864F9 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
+		59B6E27B2B185FD2000864F9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		59BD5DC82B0C760500FEB80F /* UIStackView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIStackView+.swift"; sourceTree = "<group>"; };
 		59D4DBDD2B06889300BBA2D5 /* TimePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePickerView.swift; sourceTree = "<group>"; };
 		59D4DBE12B068C6400BBA2D5 /* UIView+Layer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Layer.swift"; sourceTree = "<group>"; };
@@ -194,6 +197,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59B6E27F2B18604D000864F9 /* FirebaseAnalytics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -529,6 +533,7 @@
 		8FBE3AEC2B03547E00660530 /* Application */ = {
 			isa = PBXGroup;
 			children = (
+				59B6E27B2B185FD2000864F9 /* GoogleService-Info.plist */,
 				59E0C5FD2AFBA3FC0073D494 /* SceneDelegate.swift */,
 				59E0C5FB2AFBA3FC0073D494 /* AppDelegate.swift */,
 				4416D4492B148A7A0052BF33 /* AppTabBarController.swift */,
@@ -724,6 +729,9 @@
 			dependencies = (
 			);
 			name = Village;
+			packageProductDependencies = (
+				59B6E27E2B18604D000864F9 /* FirebaseAnalytics */,
+			);
 			productName = Village;
 			productReference = 59E0C5F82AFBA3FC0073D494 /* Village.app */;
 			productType = "com.apple.product-type.application";
@@ -756,6 +764,9 @@
 				Base,
 			);
 			mainGroup = 59E0C5EF2AFBA3FC0073D494;
+			packageReferences = (
+				59B6E27D2B18604D000864F9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
 			productRefGroup = 59E0C5F92AFBA3FC0073D494 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -779,6 +790,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5975E98A2B035919007CEF13 /* Post.json in Resources */,
+				59B6E27C2B185FD2000864F9 /* GoogleService-Info.plist in Resources */,
 				8FF7E61A2B106FBB00B6D678 /* ChatList.json in Resources */,
 				8F628D192B0349FE0013042E /* .swiftlint.yml in Resources */,
 				8F3D79DD2B135D1500370536 /* ChatRoom.json in Resources */,
@@ -1140,6 +1152,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		59B6E27D2B18604D000864F9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.18.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		59B6E27E2B18604D000864F9 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 59B6E27D2B18604D000864F9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 59E0C5F02AFBA3FC0073D494 /* Project object */;
 }

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		59B6E2732B17938C000864F9 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B6E2722B17938C000864F9 /* MyPageViewModel.swift */; };
 		59B6E27C2B185FD2000864F9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 59B6E27B2B185FD2000864F9 /* GoogleService-Info.plist */; };
 		59B6E27F2B18604D000864F9 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 59B6E27E2B18604D000864F9 /* FirebaseAnalytics */; };
+		59B6E2822B186A83000864F9 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 59B6E2812B186A83000864F9 /* FirebaseMessaging */; };
 		59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59BD5DC82B0C760500FEB80F /* UIStackView+.swift */; };
 		59BD5DCC2B0C772200FEB80F /* PostCreateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E196C82B045F4900BF7C5A /* PostCreateViewController.swift */; };
 		59BD5DCE2B0C775D00FEB80F /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0C5FD2AFBA3FC0073D494 /* SceneDelegate.swift */; };
@@ -197,6 +198,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				59B6E2822B186A83000864F9 /* FirebaseMessaging in Frameworks */,
 				59B6E27F2B18604D000864F9 /* FirebaseAnalytics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -373,6 +375,13 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		59B6E2802B186A83000864F9 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		59BD5DD02B0C785900FEB80F /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -411,6 +420,7 @@
 				59E0C5FA2AFBA3FC0073D494 /* Village */,
 				59AA129B2B03726C00AFC766 /* VillageTests */,
 				59E0C5F92AFBA3FC0073D494 /* Products */,
+				59B6E2802B186A83000864F9 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -731,6 +741,7 @@
 			name = Village;
 			packageProductDependencies = (
 				59B6E27E2B18604D000864F9 /* FirebaseAnalytics */,
+				59B6E2812B186A83000864F9 /* FirebaseMessaging */,
 			);
 			productName = Village;
 			productReference = 59E0C5F82AFBA3FC0073D494 /* Village.app */;
@@ -1169,6 +1180,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 59B6E27D2B18604D000864F9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAnalytics;
+		};
+		59B6E2812B186A83000864F9 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 59B6E27D2B18604D000864F9 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOS/Village/Village.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/Village/Village.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,122 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bfc0b6f81adc06ce5121eb23f628473638d67c5c",
+        "version" : "1.2022062300.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "5746b2d35c91c50581590ed97abe4c06b5037274",
+        "version" : "10.18.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "5de0369ee79ad096c164eb3afeb7921d92a43b58",
+        "version" : "10.18.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "6b332152355c372ace9966d8ee76ed191f97025e",
+        "version" : "10.17.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "a732a4b47f59e4f725a2ea10f0c77e93a7131117",
+        "version" : "9.3.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "bc27fad73504f3d4af235de451f02ee22586ebd3",
+        "version" : "7.12.1"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "a673bc2937fbe886dd1f99c401b01b6d977a9c98",
+        "version" : "1.49.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "115f75e43851774934d695449a4836123c3246e1",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
+        "version" : "100.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "9d108e9112aa1d65ce508facf804674546116d9c",
+        "version" : "1.22.3"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
+        "version" : "2.3.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "65e8f29b2d63c4e38e736b25c27b83e012159be8",
+        "version" : "1.25.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/iOS/Village/Village/Application/AppDelegate.swift
+++ b/iOS/Village/Village/Application/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import UserNotifications
+import FirebaseCore
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -15,6 +16,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         sleep(2)
         UINavigationBar.appearance().tintColor = .primary500
         registerForPushNotifications()
+        FirebaseApp.configure()
         return true
     }
 

--- a/iOS/Village/Village/Application/AppDelegate.swift
+++ b/iOS/Village/Village/Application/AppDelegate.swift
@@ -8,18 +8,20 @@
 import UIKit
 import UserNotifications
 import FirebaseCore
+import FirebaseMessaging
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         sleep(2)
         UINavigationBar.appearance().tintColor = .primary500
         registerForPushNotifications()
         FirebaseApp.configure()
+        Messaging.messaging().delegate = self
         return true
     }
-
+    
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
@@ -65,22 +67,39 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         completionHandler([.banner, .sound])
     }
-
+    
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-
-        let content = response.notification.request.content.userInfo
         
+        let content = response.notification.request.content.userInfo
         guard let windowSceneDelegate = response.targetScene?.delegate as? UIWindowSceneDelegate,
               let windowScene = windowSceneDelegate.window,
               let rootViewController = windowScene?.rootViewController as? AppTabBarController,
               let navigationController = rootViewController.selectedViewController as? UINavigationController,
-              let roomID = content["room_id"] as? Int else {
+              let roomIDString = content["room_id"] as? String,
+              let roomID = Int(roomIDString) else {
             completionHandler()
             return
         }
         
         navigationController.pushViewController(ChatRoomViewController(roomID: roomID), animated: true)
     }
+    
+}
 
+extension AppDelegate: MessagingDelegate {
+    
+    func application(application: UIApplication,
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Messaging.messaging().apnsToken = deviceToken
+    }
+    
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+        let dataDict: [String: String] = ["token": fcmToken ?? ""]
+        NotificationCenter.default.post(
+            name: .fcmToken,
+            object: nil,
+            userInfo: dataDict
+        )
+    }
     
 }

--- a/iOS/Village/Village/Application/AppDelegate.swift
+++ b/iOS/Village/Village/Application/AppDelegate.swift
@@ -82,6 +82,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         }
         
         navigationController.pushViewController(ChatRoomViewController(roomID: roomID), animated: true)
+        completionHandler()
     }
     
 }

--- a/iOS/Village/Village/Application/GoogleService-Info.plist
+++ b/iOS/Village/Village/Application/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyD75ap_x5PKr4Q0elhwo3ZkP10VVLOeZoY</string>
+	<key>GCM_SENDER_ID</key>
+	<string>667924926012</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>kr.codesquad.boostcamp8.Village</string>
+	<key>PROJECT_ID</key>
+	<string>village-2ed97</string>
+	<key>STORAGE_BUCKET</key>
+	<string>village-2ed97.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:667924926012:ios:450e9e2456b3a7f78a7d39</string>
+</dict>
+</plist>

--- a/iOS/Village/Village/Presentation/Utils/Extensions/NotificationName+.swift
+++ b/iOS/Village/Village/Presentation/Utils/Extensions/NotificationName+.swift
@@ -8,5 +8,8 @@
 import Foundation
 
 extension Notification.Name {
+    
     static let openChatRoom = Notification.Name("OpenChatRoom")
+    static let fcmToken = Notification.Name("FCMToken")
+    
 }

--- a/iOS/Village/Village/Presentation/Utils/Extensions/UIView+Divider.swift
+++ b/iOS/Village/Village/Presentation/Utils/Extensions/UIView+Divider.swift
@@ -14,7 +14,7 @@ extension UIView {
         case vertical
     }
     
-    static func divider(_ direction: DividerDirection, width: CGFloat = 1.0, color: UIColor = .grey100) -> UIView {
+    static func divider(_ direction: DividerDirection, width: CGFloat = 1.0, color: UIColor = .systemGray4) -> UIView {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = color

--- a/iOS/Village/Village/Resources/Info.plist
+++ b/iOS/Village/Village/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
## 이슈
- #232

## 체크리스트
- [x] Firebase와 통신할 수 있어야 한다.

## 고민한 내용
- 디바이스 토큰을 서버에 보내는 방법에 대해서 고민했습니다. 로그인을 했을 때 토큰을 같이 보내서 로그인이 만료됐을 때나 로그아웃을 했을 경우 디바이스 토큰을 같이 없애는 방법으로 구현해야 할 것 같습니다. 현재는 NotificationCenter를 이용하여 post로 토큰을 보내놓은 상태입니다. 로그인할 때 받아서 사용하면 됩니다.
