### PR TITLE
[iOS/#243] 자동 로그인 버그 수정

### DIFF
--- a/iOS/Village/Village/Application/SceneDelegate.swift
+++ b/iOS/Village/Village/Application/SceneDelegate.swift
@@ -42,7 +42,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     private func autoLogin() {
-        guard let token = JWTManager.shared.get() else { return }
+        guard let token = JWTManager.shared.get() else {
+            window?.rootViewController = LoginViewController()
+            return
+        }
         let endpoint = APIEndPoints.tokenExpire(accessToken: token.refreshToken)
         Task {
             do {
@@ -52,7 +55,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 if let err = error as? NetworkError {
                     switch err {
                     case .serverError(.forbidden):
-                        dump("forbidden came!")
                         refreshToken()
                     case .serverError(.serverError):
                         dump("서버 에러가 발생했습니다! 다시 로그인해주세요.")


### PR DESCRIPTION
## 이슈
- #243 

## 체크리스트
- [x] SceneDelegate에서 토큰 정보를 가져오는데 실패했을 때 그대로 return 되버리는 버그를 수정한다.

## 고민한 내용
없음

## 스크린샷
없음