### PR TITLE
[iOS/#285] 편집시 View, ViewModel 업데이트

### DIFF
--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateDetailView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateDetailView.swift
@@ -68,6 +68,9 @@ final class PostCreateDetailView: UIStackView {
         endEditing(true)
     }
     
+    func setEdit(detail: String) {
+        detailTextView.text = detail
+    }
 }
 
 private extension PostCreateDetailView {

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreatePriceView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreatePriceView.swift
@@ -101,6 +101,10 @@ final class PostCreatePriceView: UIStackView {
         priceTextField.text = text
     }
     
+    func setEdit(price: Int?) {
+        priceTextField.text = price?.priceText()
+    }
+    
 }
 
 private extension PostCreatePriceView {

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
@@ -181,6 +181,26 @@ final class PostCreateTimeView: UIStackView {
         timeWarningLabel.alpha = alpha
     }
     
+    func setEdit(time: String) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy.MM.dd"
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateFormat = "HH:mm"
+        let fullTimeString = time.components(separatedBy: "T")
+        guard let dateString = fullTimeString.first,
+              let timeString = fullTimeString.last else {
+            return
+        }
+        guard let date = dateFormatter.date(from: dateString),
+              let hourIndex = hours.firstIndex(of: String(timeString.prefix(5))) else {
+            return
+        }
+        datePicker.date = date
+        hourPicker.selectRow(hourIndex, inComponent: 0, animated: false)
+        dateTextField.text = dateString
+        hourTextField.text = String(timeString.prefix(5))
+    }
+    
 }
 
 private extension PostCreateTimeView {

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
@@ -183,22 +183,22 @@ final class PostCreateTimeView: UIStackView {
     
     func setEdit(time: String) {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy.MM.dd"
-        let timeFormatter = DateFormatter()
-        timeFormatter.dateFormat = "HH:mm"
-        let fullTimeString = time.components(separatedBy: "T")
-        guard let dateString = fullTimeString.first,
-              let timeString = fullTimeString.last else {
-            return
-        }
-        guard let date = dateFormatter.date(from: dateString),
-              let hourIndex = hours.firstIndex(of: String(timeString.prefix(5))) else {
-            return
-        }
-        datePicker.date = date
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+        guard let timeDate = dateFormatter.date(from: time) else { return }
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let dateString = dateFormatter.string(from: timeDate)
+        dateFormatter.dateFormat = "HH:mm"
+        let hourString = dateFormatter.string(from: timeDate)
+        
+        selectedDate = dateString
+        selectedHour = hourString
+        datePicker.date = timeDate
+        
+        guard let hourIndex = hours.firstIndex(of: hourString) else { return }
         hourPicker.selectRow(hourIndex, inComponent: 0, animated: false)
         dateTextField.text = dateString
-        hourTextField.text = String(timeString.prefix(5))
+        hourTextField.text = hourString
+        setTime()
     }
     
 }

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTitleView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTitleView.swift
@@ -91,6 +91,10 @@ final class PostCreateTitleView: UIStackView {
         titleWarningLabel.alpha = alpha
     }
     
+    func setEdit(title: String) {
+        titleTextField.text = title
+    }
+    
 }
 
 private extension PostCreateTitleView {

--- a/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
@@ -186,6 +186,25 @@ final class PostCreateViewController: UIViewController {
                 self?.postCreatePriceView.warn(!bool)
             }
             .store(in: &cancellableBag)
+        
+        output.endResult
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.dismiss(animated: true)
+            }
+            .store(in: &cancellableBag)
+        
+    }
+    
+    func setEdit(post: PostResponseDTO) {
+        postCreateTitleView.setEdit(title: post.title)
+        postCreateDetailView.setEdit(detail: post.description)
+        postCreateStartTimeView.setEdit(time: post.startDate)
+        postCreateEndTimeView.setEdit(time: post.endDate)
+        if !post.isRequest {
+            postCreatePriceView.setEdit(price: post.price)
+        }
+        viewModel.setEdit(post: post)
     }
     
 }

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -25,13 +25,13 @@ final class PostCreateViewModel {
     private var isValidEndTime: Bool = false
     private var isValidPrice: Bool = false
     private var isValidPostCreate: Bool {
-        let rentBool = 
+        let rentBool =
         !isRequest &&
         isValidTitle &&
         isValidStartTime &&
         isValidEndTime &&
         isValidPrice
-        let requestBool = 
+        let requestBool =
         isRequest &&
         isValidTitle &&
         isValidStartTime &&
@@ -45,6 +45,7 @@ final class PostCreateViewModel {
     private let postButtonTappedStartTimeWarningOutput = PassthroughSubject<Bool, Never>()
     private let postButtonTappedEndTimeWarningOutput = PassthroughSubject<Bool, Never>()
     private let postButtonTappedPriceWarningOutput = PassthroughSubject<Bool, Never>()
+    private let endOutput = PassthroughSubject<Void, Never>()
     
     private var cancellableBag = Set<AnyCancellable>()
     
@@ -178,6 +179,7 @@ final class PostCreateViewModel {
                     } else {
                         postCreate()
                     }
+                    endOutput.send()
                 } else {
                     postButtonTappedTitleWarningOutput.send(isValidTitle)
                     postButtonTappedStartTimeWarningOutput.send(isValidStartTime)
@@ -193,8 +195,22 @@ final class PostCreateViewModel {
             postButtonTappedTitleWarningResult: postButtonTappedTitleWarningOutput.eraseToAnyPublisher(),
             postButtonTappedStartTimeWarningResult: postButtonTappedStartTimeWarningOutput.eraseToAnyPublisher(),
             postButtonTappedEndTimeWarningResult: postButtonTappedEndTimeWarningOutput.eraseToAnyPublisher(),
-            postButtonTappedPriceWarningResult: postButtonTappedPriceWarningOutput.eraseToAnyPublisher()
+            postButtonTappedPriceWarningResult: postButtonTappedPriceWarningOutput.eraseToAnyPublisher(),
+            endResult: endOutput.eraseToAnyPublisher()
         )
+    }
+    
+    func setEdit(post: PostResponseDTO) {
+        titleInput = post.title
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.000Z"
+        startTimeInput = formatter.date(from: post.startDate)
+        endTimeInput = formatter.date(from: post.endDate)
+        if !isRequest {
+            priceInput = post.price
+        }
+        detailInput = post.description
+        validate()
     }
     
 }
@@ -250,6 +266,7 @@ extension PostCreateViewModel {
         var postButtonTappedStartTimeWarningResult: AnyPublisher<Bool, Never>
         var postButtonTappedEndTimeWarningResult: AnyPublisher<Bool, Never>
         var postButtonTappedPriceWarningResult: AnyPublisher<Bool, Never>
+        var endResult: AnyPublisher<Void, Never>
         
     }
     

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -137,10 +137,10 @@ final class PostDetailViewController: UIViewController {
                 isEdit: true,
                 postID: self?.postID.output
             )
-            let viewController = PostCreateViewController(viewModel: postCreateViewModel)
+            let editVC = PostCreateViewController(viewModel: postCreateViewModel)
             guard let post = self?.viewModel.postDTO else { return }
-            self?.present(viewController, animated: true)
-            viewController.setEdit(post: post)
+            self?.present(editVC, animated: true)
+            editVC.setEdit(post: post)
         }
         
         let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { _ in

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -128,15 +128,26 @@ final class PostDetailViewController: UIViewController {
     private func moreBarButtonTapped() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
-        let modifyAction = UIAlertAction(title: "게시글 편집하기", style: .default) { _ in
-            // TODO: modify post
+        let modifyAction = UIAlertAction(title: "편집하기", style: .default) { [weak self] _ in
+            guard let isRequest = self?.isRequest  else { return }
+            let useCase = PostCreateUseCase(postCreateRepository: PostCreateRepository())
+            let postCreateViewModel = PostCreateViewModel(
+                useCase: useCase,
+                isRequest: isRequest,
+                isEdit: true,
+                postID: self?.postID.output
+            )
+            let viewController = PostCreateViewController(viewModel: postCreateViewModel)
+            guard let post = self?.viewModel.postDTO else { return }
+            self?.present(viewController, animated: true)
+            viewController.setEdit(post: post)
         }
         
-        let deleteAction = UIAlertAction(title: "게시글 삭제하기", style: .destructive) { _ in
+        let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { _ in
             // TODO: delete post
         }
         
-        let hideAction = UIAlertAction(title: "이 글 숨기기", style: .default) { _ in
+        let hideAction = UIAlertAction(title: "숨기기", style: .default) { _ in
             // TODO: hide post
         }
         

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -13,6 +13,7 @@ final class PostDetailViewModel {
     private var post = PassthroughSubject<PostResponseDTO, NetworkError>()
     private var user = PassthroughSubject<UserResponseDTO, NetworkError>()
     private var cancellableBag = Set<AnyCancellable>()
+    var postDTO: PostResponseDTO?
     
     func transform(input: Input) -> Output {
         input.postID
@@ -37,6 +38,16 @@ final class PostDetailViewModel {
             do {
                 guard let data = try await APIProvider.shared.request(with: endpoint) else { return }
                 post.send(data)
+                postDTO = PostResponseDTO(
+                    title: data.title,
+                    description: data.description,
+                    price: data.price,
+                    userID: data.userID,
+                    imageURL: data.imageURL,
+                    isRequest: data.isRequest,
+                    startDate: data.startDate,
+                    endDate: data.endDate
+                )
             } catch let error as NetworkError {
                 post.send(completion: .failure(error))
             }


### PR DESCRIPTION
## 이슈
- #285

## 체크리스트
- [x] 편집을 눌렀을 때, 작성되어 있던 게시글의 정보가 미리 적혀있어야 한다.
- [x] 네트워크 API 통신을 확인한다.
- [x] 편집을 성공하면 화면이 사라져야 한다.

## 고민한 내용
- 시간을 나타낼 때 서버에서 주는 것을 Date로 바꾸지 않고 사용하면 9시간 차이가 생긴다. Date로 한번 변환하고 사용해야 우리가 원하는 시간을 얻을 수 있다.
- 네트워크 API 통신을 한 뒤 DetailView를 업데이트 하기 위해서 UseCase를 나눠야 할 것 같다.
