### PR TITLE
[iOS/#303] JWT 키체인 유저 해시 아이디 저장 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		444A50942B0C8D1900454397 /* UIView+Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444A50932B0C8D1900454397 /* UIView+Divider.swift */; };
 		444A50982B0CE25200454397 /* DurationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444A50972B0CE25200454397 /* DurationView.swift */; };
 		444A509A2B0CE94E00454397 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 444A50992B0CE94E00454397 /* DateView.swift */; };
+		445D62B02B1DD6EC005DD3B1 /* AuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 445D62AF2B1DD6EC005DD3B1 /* AuthInterceptor.swift */; };
 		4461F39D2B1786DA00723C55 /* JWTManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4461F39C2B1786DA00723C55 /* JWTManager.swift */; };
 		446362C92B0DF9E800B74DA7 /* PriceLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446362C82B0DF9E800B74DA7 /* PriceLabel.swift */; };
 		446362CB2B0DFD4F00B74DA7 /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446362CA2B0DFD4F00B74DA7 /* Int+.swift */; };
@@ -123,6 +124,7 @@
 		444A50932B0C8D1900454397 /* UIView+Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Divider.swift"; sourceTree = "<group>"; };
 		444A50972B0CE25200454397 /* DurationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DurationView.swift; sourceTree = "<group>"; };
 		444A50992B0CE94E00454397 /* DateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
+		445D62AF2B1DD6EC005DD3B1 /* AuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthInterceptor.swift; sourceTree = "<group>"; };
 		4461F39C2B1786DA00723C55 /* JWTManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JWTManager.swift; sourceTree = "<group>"; };
 		446362C82B0DF9E800B74DA7 /* PriceLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PriceLabel.swift; sourceTree = "<group>"; };
 		446362CA2B0DFD4F00B74DA7 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
@@ -556,6 +558,7 @@
 			isa = PBXGroup;
 			children = (
 				8F95CF9B2B0C81640024631F /* APIProvider.swift */,
+				445D62AF2B1DD6EC005DD3B1 /* AuthInterceptor.swift */,
 			);
 			path = APIProvider;
 			sourceTree = "<group>";
@@ -910,6 +913,7 @@
 				8F95CF9A2B0C7C440024631F /* EndPoint.swift in Sources */,
 				4416D47E2B171BF30052BF33 /* LoginViewModel.swift in Sources */,
 				8F95CF942B0C60E00024631F /* HTTPMethod.swift in Sources */,
+				445D62B02B1DD6EC005DD3B1 /* AuthInterceptor.swift in Sources */,
 				8F3D79E22B14438A00370536 /* PostView.swift in Sources */,
 				59E0C5FC2AFBA3FC0073D494 /* AppDelegate.swift in Sources */,
 				59AABDDF2B0E1AE1002F6D0E /* PostCreateTitleView.swift in Sources */,
@@ -1005,6 +1009,7 @@
 			buildSettings = {
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = B3PWYBKFUK;
 				PRODUCT_NAME = Village;
 			};
 			name = Release;
@@ -1166,7 +1171,7 @@
 				59AA12A12B03726C00AFC766 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		59E0C5F32AFBA3FC0073D494 /* Build configuration list for PBXProject "Village" */ = {
 			isa = XCConfigurationList;
@@ -1175,7 +1180,7 @@
 				59E0C60B2AFBA3FE0073D494 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 		59E0C60C2AFBA3FE0073D494 /* Build configuration list for PBXNativeTarget "Village" */ = {
 			isa = XCConfigurationList;
@@ -1184,7 +1189,7 @@
 				59B6E2702B17931F000864F9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -11,19 +11,12 @@ struct APIEndPoints {
     
     static let baseURL = "https://www.village-api.shop/"
     
-    static var header: [String: String]? {
-        guard let accessToken = JWTManager.shared.get()?.accessToken else { return nil }
-        
-        return ["Authorization": "Bearer \(accessToken)"]
-    }
-    
     static func getPosts(with requestDTO: PostListRequestDTO) -> EndPoint<[PostListResponseDTO]> {
         return EndPoint(
             baseURL: baseURL,
             path: "posts",
             method: .GET,
-            queryParameters: requestDTO,
-            headers: header
+            queryParameters: requestDTO
         )
     }
     
@@ -31,8 +24,7 @@ struct APIEndPoints {
         return EndPoint(
             baseURL: baseURL,
             path: "posts/\(id)",
-            method: .GET,
-            headers: header
+            method: .GET
         )
     }
     
@@ -40,8 +32,7 @@ struct APIEndPoints {
         return EndPoint(
             baseURL: baseURL,
             path: "users/\(id)",
-            method: .GET,
-            headers: header
+            method: .GET
         )
     }
     
@@ -51,7 +42,7 @@ struct APIEndPoints {
             path: "posts",
             method: .POST,
             bodyParameters: requestDTO.httpBody,
-            headers: header?.mergeWith(["Content-Type": "multipart/form-data; boundary=\(requestDTO.boundary)"])
+            headers: ["Content-Type": "multipart/form-data; boundary=\(requestDTO.boundary)"]
         )
     }
     
@@ -60,8 +51,7 @@ struct APIEndPoints {
             baseURL: baseURL,
             path: "chat",
             method: .GET,
-            queryParameters: chatListResponse,
-            headers: header
+            queryParameters: chatListResponse
         )
     }
     
@@ -79,8 +69,7 @@ struct APIEndPoints {
         EndPoint(
             baseURL: baseURL,
             path: "login/expire",
-            method: .GET,
-            headers: header
+            method: .GET
         )
     }
     
@@ -92,14 +81,8 @@ struct APIEndPoints {
             path: "login/refresh",
             method: .POST,
             bodyParameters: body,
-            headers: header?.mergeWith(["Content-Type": "application/json"])
+            headers: ["Content-Type": "application/json"]
         )
     }
   
-}
-
-fileprivate extension Dictionary<String, String> {
-    func mergeWith(_ dict: [String: String]) -> [String: String]? {
-        return self.merging(dict) { (current, _) in current }
-    }
 }

--- a/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
@@ -57,3 +57,34 @@ final class JWTManager {
     }
     
 }
+
+fileprivate extension String {
+    
+    func base64UrlDecode(_ value: String) -> Data? {
+        var base64 = value
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
+        let requiredLength = 4 * ceil(length / 4.0)
+        let paddingLength = requiredLength - length
+        if paddingLength > 0 {
+            let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
+            base64 += padding
+        }
+        return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+    }
+    
+    func decodeJWTPart(_ value: String) -> [String: Any]? {
+        guard let bodyData = base64UrlDecode(value),
+              let json = try? JSONSerialization.jsonObject(with: bodyData, options: []),
+              let payload = json as? [String: Any] else { return nil }
+        return payload
+    }
+    
+    func decode() -> [String: Any] {
+        let segments = self.components(separatedBy: ".")
+        return decodeJWTPart(segments[1]) ?? [:]
+    }
+    
+}

--- a/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
@@ -11,49 +11,45 @@ final class JWTManager {
     
     static let shared = JWTManager()
     
-    private let lastLoggedEmailKey = "lastLoggedEmail"
-    private var userEmail: String? {
-        UserDefaults.standard.string(forKey: lastLoggedEmailKey)
+    private let keychainManager = KeychainManager<AuthenticationToken>()
+    
+    private let currentUserIDKey = "currentUserID"
+    private var currentUserID: String? {
+        UserDefaults.standard.string(forKey: currentUserIDKey)
     }
     
     func get() -> AuthenticationToken? {
-        guard let email = userEmail else { return nil }
+        guard let userID = currentUserID else { return nil }
         
-        return KeychainManager.shared.read(email: email)
+        return keychainManager.read(key: userID)
     }
     
-    func save(email: String, token: AuthenticationToken) {
-        UserDefaults.standard.setValue(email, forKey: lastLoggedEmailKey)
+    func save(token: AuthenticationToken) throws {
+        guard let userID = token.accessToken.decode()["userId"] as? String else { return }
+        
+        UserDefaults.standard.setValue(userID, forKey: currentUserIDKey)
         
         do {
-            try KeychainManager.shared.write(email: email, token: token)
+            try keychainManager.write(key: userID, value: token)
         } catch let error as KeychainError {
             if case .duplicate = error {
-                try? KeychainManager.shared.update(email: email, token: token)
+                try? keychainManager.update(key: userID, newValue: token)
             }
         } catch let error {
-            dump(error)
+            throw error
         }
     }
     
     func delete() throws {
-        guard let email = userEmail else { return }
+        guard let userID = currentUserID else { return }
         
-        do {
-            try KeychainManager.shared.delete(email: email)
-        } catch let error {
-            dump(error)
-        }
+        try keychainManager.delete(key: userID)
     }
     
     func update(token: AuthenticationToken) throws {
-        guard let email = userEmail else { return }
+        guard let userID = currentUserID else { return }
         
-        do {
-            try KeychainManager.shared.update(email: email, token: token)
-        } catch let error {
-            dump(error)
-        }
+        try keychainManager.update(key: userID, newValue: token)
     }
     
 }

--- a/iOS/Village/Village/Network/APIProvider/AuthInterceptor.swift
+++ b/iOS/Village/Village/Network/APIProvider/AuthInterceptor.swift
@@ -1,0 +1,70 @@
+//
+//  AuthInterceptor.swift
+//  Village
+//
+//  Created by 정상윤 on 12/4/23.
+//
+
+import Foundation
+
+protocol Interceptor {
+    func adapt(request: URLRequest) -> URLRequest?
+    func retry(request: URLRequest, error: Error, attempt: Int) async -> RetryResult
+}
+
+enum RetryResult {
+    case retry
+    case doNotRetry
+    case doNotRetryWithError(Error)
+}
+
+struct AuthInterceptor: Interceptor {
+    
+    private let session: URLSession
+    private let maxAttempt: Int
+    
+    init(session: URLSession = .shared, maxAttempt: Int = 3) {
+        self.session = session
+        self.maxAttempt = maxAttempt
+    }
+    
+    func adapt(request: URLRequest) -> URLRequest? {
+        guard let accessToken = JWTManager.shared.get()?.accessToken else { return request }
+        
+        var urlRequest = request
+        urlRequest.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        return urlRequest
+    }
+    
+    func retry(request: URLRequest, error: Error, attempt: Int) async -> RetryResult {
+        if attempt > maxAttempt {
+            return .doNotRetry
+        }
+        if let networkError = error as? NetworkError,
+           case .serverError(let serverError) = networkError, case .forbidden = serverError {
+            do {
+                try await refreshToken()
+                return .retry
+            } catch let error {
+                return .doNotRetryWithError(error)
+            }
+        } else {
+            return .retry
+        }
+    }
+    
+}
+
+private extension AuthInterceptor {
+    
+    func refreshToken() async throws {
+        do {
+            guard let refreshToken = JWTManager.shared.get()?.refreshToken else { return }
+            let endpoint = APIEndPoints.tokenRefresh(refreshToken: refreshToken)
+            guard let newToken = try await APIProvider.shared.request(with: endpoint) else { return }
+            
+            try JWTManager.shared.update(token: newToken)
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/Login/ViewModel/LoginViewModel.swift
+++ b/iOS/Village/Village/Presentation/Login/ViewModel/LoginViewModel.swift
@@ -56,34 +56,3 @@ extension LoginViewModel {
     }
     
 }
-
-fileprivate extension String {
-    
-    func base64UrlDecode(_ value: String) -> Data? {
-        var base64 = value
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-
-        let length = Double(base64.lengthOfBytes(using: String.Encoding.utf8))
-        let requiredLength = 4 * ceil(length / 4.0)
-        let paddingLength = requiredLength - length
-        if paddingLength > 0 {
-            let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
-            base64 += padding
-        }
-        return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
-    }
-    
-    func decodeJWTPart(_ value: String) -> [String: Any]? {
-        guard let bodyData = base64UrlDecode(value),
-              let json = try? JSONSerialization.jsonObject(with: bodyData, options: []),
-              let payload = json as? [String: Any] else { return nil }
-        return payload
-    }
-    
-    func decode() -> [String: Any] {
-        let segments = self.components(separatedBy: ".")
-        return decodeJWTPart(segments[1]) ?? [:]
-    }
-    
-}


### PR DESCRIPTION
## 이슈
- #303 

## 체크리스트
- [x] JWT 파싱 구현
- [x] JWTManager keychainManager 사용 쿼리 키 변경

## 고민한 내용
- JWT로부터 파싱한 유저 아이디를 저장하여 사용하는 것이 아직까지는 불가피해 보이기 때문에 save 시점에서 UserDefaults에 저장하도록 했습니다.

## 스크린샷
없음