### PR TITLE
[BE/#299] 웹소켓 인가 처리

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -45,6 +45,7 @@
         "@types/multer-s3": "^3.0.3",
         "@types/node": "^20.3.1",
         "@types/supertest": "^2.0.12",
+        "@types/ws": "^8.5.10",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "eslint": "^8.42.0",
@@ -4105,6 +4106,15 @@
       "version": "13.11.7",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.7.tgz",
       "integrity": "sha512-q0JomTsJ2I5Mv7dhHhQLGjMvX0JJm5dyZ1DXQySIUzU1UlwzB8bt+R6+LODUbz0UDIOvEzGc28tk27gBJw2N8Q=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
+      "integrity": "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.31",

--- a/BE/package.json
+++ b/BE/package.json
@@ -56,6 +56,7 @@
     "@types/multer-s3": "^3.0.3",
     "@types/node": "^20.3.1",
     "@types/supertest": "^2.0.12",
+    "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.42.0",

--- a/BE/src/chat/chats.gateway.ts
+++ b/BE/src/chat/chats.gateway.ts
@@ -7,24 +7,34 @@ import {
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
-import { Server, Websocket } from 'ws';
+import { Server, WebSocket } from 'ws';
 import { ChatService } from './chat.service';
 import { ChatDto } from './dto/chat.dto';
 import { Logger } from '@nestjs/common';
 
+interface ChatWebSocket extends WebSocket {
+  roomId: number;
+  userId: string;
+}
 @WebSocketGateway({
   path: 'chats',
 })
 export class ChatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer() server: Server;
-  private rooms = new Map<number, Set<Websocket>>();
+  private rooms = new Map<number, Set<ChatWebSocket>>();
   private readonly logger = new Logger('ChatsGateway');
   constructor(private readonly chatService: ChatService) {}
-  handleConnection(client: Websocket) {
-    this.logger.debug(`on connnect : ${client}`, 'ChatsGateway');
+  handleConnection(client: ChatWebSocket, ...args) {
+    const { authorization } = args[0].headers;
+    const userId = this.chatService.validateUser(authorization);
+    if (userId === null) {
+      client.close(1008, '토큰이 유효하지 않습니다.');
+    }
+    client.userId = userId;
+    this.logger.debug(`[${userId}] on connect`, 'ChatsGateway');
   }
 
-  handleDisconnect(client: Websocket) {
+  handleDisconnect(client: ChatWebSocket) {
     if (client.roomId) {
       const roomId = client.roomId;
       const room = this.rooms.get(roomId);
@@ -34,7 +44,7 @@ export class ChatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
       }
     }
     this.logger.debug(
-      `on disconnect : ${client}, left rooms : ${Array.from(
+      `[${client.userId}] on disconnect => left rooms : ${Array.from(
         this.rooms.keys(),
       )}`,
       'ChatsGateway',
@@ -44,10 +54,10 @@ export class ChatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('send-message')
   async sendMessage(
     @MessageBody() message: ChatDto,
-    @ConnectedSocket() client: Websocket,
+    @ConnectedSocket() client: ChatWebSocket,
   ) {
     this.logger.debug(
-      `[send message] room ID: ${message['room_id']} , sender: ${message['sender']}, message: ${message['message']}`,
+      `[${client.userId}] send message { room ID: ${message['room_id']} , sender: ${message['sender']}, message: ${message['message']} }`,
     );
     const room = this.rooms.get(message['room_id']);
     const sender = message['sender'];
@@ -66,19 +76,22 @@ export class ChatsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @SubscribeMessage('join-room')
   joinRoom(
     @MessageBody() message: object,
-    @ConnectedSocket() client: Websocket,
+    @ConnectedSocket() client: ChatWebSocket,
   ) {
     const roomId = message['room_id'];
     client.roomId = roomId;
     if (this.rooms.has(roomId)) this.rooms.get(roomId).add(client);
     else this.rooms.set(roomId, new Set([client]));
-    this.logger.debug(`join room : ${roomId}`, 'ChatsGateway');
+    this.logger.debug(
+      `[${client.userId}] join room : ${roomId}`,
+      'ChatsGateway',
+    );
   }
 
   @SubscribeMessage('leave-room')
   leaveRoom(
     @MessageBody() message: object,
-    @ConnectedSocket() client: Websocket,
+    @ConnectedSocket() client: ChatWebSocket,
   ) {
     const roomId = message['room_id'];
     const room = this.rooms.get(roomId);


### PR DESCRIPTION
## 이슈
- #299

## 체크리스트
- [x] 헤더의 jwt를 검증 하는 로직 추가
- [x] 미인증 유저의 경우 연결이 끊기도록 구현

## 고민한 내용
- socket.io 와 다르게 nest의 가드가 적용되지 않아 직접 헤더에서 jwt를 추출해서 검사하는 로직을 추가하였다. 
- http로 403을 응답해주는 방법을 찾지 못해서 웹소켓의 연결을 끊고 1008 번을 주는 방식으로 구현하였다.

## 스크린샷
