### PR TITLE
[iOS/#287] 채팅하기 버튼 후 채팅방 생성

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		8F3D7A3A2B173B7C00370536 /* WebSocketError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3D7A392B173B7C00370536 /* WebSocketError.swift */; };
 		8F3D7A3C2B175D5000370536 /* chat-server.ts in Resources */ = {isa = PBXBuildFile; fileRef = 8F3D7A3B2B175D5000370536 /* chat-server.ts */; };
 		8F628D192B0349FE0013042E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 8F628D182B0349FE0013042E /* .swiftlint.yml */; };
+		8F8F0B932B1DC0C300BE97D2 /* PostRoomRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8F0B922B1DC0C300BE97D2 /* PostRoomRequestDTO.swift */; };
+		8F8F0B952B1DC0CE00BE97D2 /* PostRoomResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8F0B942B1DC0CE00BE97D2 /* PostRoomResponseDTO.swift */; };
 		8F95CF902B0B97F90024631F /* PostSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F95CF8F2B0B97F90024631F /* PostSummaryView.swift */; };
 		8F95CF922B0C57460024631F /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F95CF912B0C57460024631F /* NetworkError.swift */; };
 		8F95CF942B0C60E00024631F /* HTTPMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F95CF932B0C60E00024631F /* HTTPMethod.swift */; };
@@ -175,6 +177,8 @@
 		8F3D7A3B2B175D5000370536 /* chat-server.ts */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.typescript; path = "chat-server.ts"; sourceTree = "<group>"; };
 		8F3D7A3E2B18ED2300370536 /* VillageRelease.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = VillageRelease.entitlements; sourceTree = "<group>"; };
 		8F628D182B0349FE0013042E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		8F8F0B922B1DC0C300BE97D2 /* PostRoomRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRoomRequestDTO.swift; sourceTree = "<group>"; };
+		8F8F0B942B1DC0CE00BE97D2 /* PostRoomResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRoomResponseDTO.swift; sourceTree = "<group>"; };
 		8F95CF8F2B0B97F90024631F /* PostSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSummaryView.swift; sourceTree = "<group>"; };
 		8F95CF912B0C57460024631F /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		8F95CF932B0C60E00024631F /* HTTPMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPMethod.swift; sourceTree = "<group>"; };
@@ -499,6 +503,8 @@
 				8F1B53372B0E03AE006D8982 /* PostListResponseDTO.swift */,
 				44C1F5EC2B0FE44A0047A436 /* UserResponseDTO.swift */,
 				44C1F5F22B0FF63C0047A436 /* PostResponseDTO.swift */,
+				8F8F0B922B1DC0C300BE97D2 /* PostRoomRequestDTO.swift */,
+				8F8F0B942B1DC0CE00BE97D2 /* PostRoomResponseDTO.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -883,6 +889,7 @@
 				8F1B53322B0DE0D8006D8982 /* APIEndPoints.swift in Sources */,
 				4416D4832B171C730052BF33 /* AuthenticationToken.swift in Sources */,
 				59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */,
+				8F8F0B932B1DC0C300BE97D2 /* PostRoomRequestDTO.swift in Sources */,
 				59BA10FA2B1CC3F700F30DB8 /* FCMManager.swift in Sources */,
 				8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */,
 				8F1B53382B0E03AE006D8982 /* PostListResponseDTO.swift in Sources */,
@@ -919,6 +926,7 @@
 				8F3D79E22B14438A00370536 /* PostView.swift in Sources */,
 				59E0C5FC2AFBA3FC0073D494 /* AppDelegate.swift in Sources */,
 				59AABDDF2B0E1AE1002F6D0E /* PostCreateTitleView.swift in Sources */,
+				8F8F0B952B1DC0CE00BE97D2 /* PostRoomResponseDTO.swift in Sources */,
 				444A509A2B0CE94E00454397 /* DateView.swift in Sources */,
 				59D4DBDE2B06889300BBA2D5 /* TimePickerView.swift in Sources */,
 				59AABDE32B0E272C002F6D0E /* PostCreateTimeView.swift in Sources */,

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -75,6 +75,19 @@ struct APIEndPoints {
         )
     }
     
+    static func postCreateChatRoom(with postRoomRequest: PostRoomRequestDTO) -> EndPoint<PostRoomResponseDTO> {
+        return EndPoint(
+            baseURL: baseURL,
+            path: "chat/room",
+            method: .POST,
+            bodyParameters: postRoomRequest,
+            headers: header?.mergeWith([
+                "Content-Type": "application/json",
+                "accept": "application/json"
+            ])
+        )
+    }
+    
     static func loginAppleOAuth(with appleOAuthDTO: AppleOAuthDTO) -> EndPoint<AuthenticationToken> {
         EndPoint(
             baseURL: baseURL,

--- a/iOS/Village/Village/Domain/Network/PostRoomRequestDTO.swift
+++ b/iOS/Village/Village/Domain/Network/PostRoomRequestDTO.swift
@@ -1,0 +1,20 @@
+//
+//  PostRoomRequestDTO.swift
+//  Village
+//
+//  Created by 박동재 on 2023/12/04.
+//
+
+import Foundation
+
+struct PostRoomRequestDTO: Codable {
+    
+    let writer: String
+    let postID: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case writer
+        case postID = "post_id"
+    }
+    
+}

--- a/iOS/Village/Village/Domain/Network/PostRoomResponseDTO.swift
+++ b/iOS/Village/Village/Domain/Network/PostRoomResponseDTO.swift
@@ -1,0 +1,18 @@
+//
+//  PostRoomResponseDTO.swift
+//  Village
+//
+//  Created by 박동재 on 2023/12/04.
+//
+
+import Foundation
+
+struct PostRoomResponseDTO: Codable {
+    
+    let roomID: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case roomID = "room_id"
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -98,6 +98,7 @@ final class PostDetailViewController: UIViewController {
                                                     .foregroundColor: UIColor.white])
         button.setAttributedTitle(title, for: .normal)
         button.layer.cornerRadius = 6
+        button.addTarget(target, action: #selector(chatButtonTapped), for: .touchUpInside)
         
         return button
     }()
@@ -161,7 +162,10 @@ final class PostDetailViewController: UIViewController {
     
     @objc
     private func chatButtonTapped() {
-        // TODO: 채팅하기 버튼 기능 구현
+        guard let roomID = viewModel.createChatRoom(writer: "qwe", postID: 47) else { return }
+        let nextVC = ChatRoomViewController(roomID: roomID.roomID)
+        nextVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(nextVC, animated: true)
     }
     
     private func setPostContent(post: PostResponseDTO) {

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -12,7 +12,24 @@ final class PostDetailViewModel {
     
     private var post = PassthroughSubject<PostResponseDTO, NetworkError>()
     private var user = PassthroughSubject<UserResponseDTO, NetworkError>()
+    private var responseData: PostRoomResponseDTO?
     private var cancellableBag = Set<AnyCancellable>()
+    
+    func createChatRoom(writer: String, postID: Int) -> PostRoomResponseDTO? {
+        let request = PostRoomRequestDTO(writer: writer, postID: postID)
+        let endpoint = APIEndPoints.postCreateChatRoom(with: request)
+        Task {
+            do {
+                guard let data = try await APIProvider.shared.request(with: endpoint) else { return }
+                print(data)
+                responseData = data
+            } catch let error as NetworkError {
+                dump(error)
+            }
+        }
+        
+        return responseData
+    }
     
     func transform(input: Input) -> Output {
         input.postID

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -21,7 +21,6 @@ final class PostDetailViewModel {
         Task {
             do {
                 guard let data = try await APIProvider.shared.request(with: endpoint) else { return }
-                print(data)
                 responseData = data
             } catch let error as NetworkError {
                 dump(error)


### PR DESCRIPTION
## 이슈
- #287

## 체크리스트
- [x] 버튼을 눌렀을 때, 서버로 방 생성
- [x] 생성된 방으로 이동

## 고민한 내용
- 방번호를 어디서 받아올 지 고민 -> 뷰모델에서 생성후 뷰컨트롤러에 번호를 넘겨주고 그 번호의 방으로 이동

## 스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-12-05 at 13 07 39](https://github.com/boostcampwm2023/iOS05-Village/assets/59719500/708bba70-bed8-4788-8b7a-a816a026acdd)

