### PR TITLE
[BE/#318] 프로필 기본 이미지 전송

### DIFF
--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -11,6 +11,7 @@ import { PostImageEntity } from '../entities/postImage.entity';
 import { BlockUserEntity } from '../entities/blockUser.entity';
 import { BlockPostEntity } from '../entities/blockPost.entity';
 import { RegistrationTokenEntity } from '../entities/registrationToken.entity';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class UsersService {
@@ -28,6 +29,7 @@ export class UsersService {
     @InjectRepository(RegistrationTokenEntity)
     private registrationTokenRepository: Repository<RegistrationTokenEntity>,
     private s3Handler: S3Handler,
+    private configService: ConfigService,
   ) {}
 
   async createUser(imageLocation: string, createUserDto: CreateUserDto) {
@@ -46,6 +48,9 @@ export class UsersService {
       where: { user_hash: userId },
     });
     if (user) {
+      if (user.profile_img === null) {
+        user.profile_img = this.configService.get('DEFAULT_PROFILE_IMAGE');
+      }
       return { nickname: user.nickname, profile_img: user.profile_img };
     } else {
       return null;


### PR DESCRIPTION
## 이슈
- #318

## 체크리스트
- [x] 프로필 사진이 null 일 때 기본이미지를 전송

## 고민한 내용
- 프로필 사진이 기본 사진이 일 때 db에 기본사진에 해당하는 사진 주소를 넣을까 고민했는데 이렇게 되면 기본사진인경우와 사진이 있는 경우를 구별하지 못 할 것 같았다. 그래서 db에는 널로 두되 클라이언트에 보낼 때만 기본 사진으로 사진을 대체 해서 보내는 방법을 선택했다.

## 스크린샷
