### PR TITLE
[iOS/#301] 편집 완료시 상세 페이지 새로고침

### DIFF
--- a/iOS/Village/.swiftlint.yml
+++ b/iOS/Village/.swiftlint.yml
@@ -2,7 +2,6 @@
 disabled_rules:
     - trailing_whitespace                    # 후행 공백
     - file_length
-    - function_body_length
     
 # 식별자 네이밍 커스텀 정의
 identifier_name:

--- a/iOS/Village/.swiftlint.yml
+++ b/iOS/Village/.swiftlint.yml
@@ -2,6 +2,7 @@
 disabled_rules:
     - trailing_whitespace                    # 후행 공백
     - file_length
+    - function_body_length
     
 # 식별자 네이밍 커스텀 정의
 identifier_name:

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -418,9 +418,9 @@
 			isa = PBXGroup;
 			children = (
 				59AABDDE2B0E1AE1002F6D0E /* PostCreateTitleView.swift */,
-				59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */,
 				59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */,
 				59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */,
+				59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */,
 				59D4DBDD2B06889300BBA2D5 /* TimePickerView.swift */,
 			);
 			path = Custom;

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -58,7 +58,7 @@
 		59D4DBDE2B06889300BBA2D5 /* TimePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D4DBDD2B06889300BBA2D5 /* TimePickerView.swift */; };
 		59D4DBE22B068C6400BBA2D5 /* UIView+Layer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D4DBE12B068C6400BBA2D5 /* UIView+Layer.swift */; };
 		59D8F1032B0FC4F700A08E02 /* PostCreateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D8F1022B0FC4F700A08E02 /* PostCreateViewModel.swift */; };
-		59D8F1052B103A7200A08E02 /* PostCreateRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D8F1042B103A7200A08E02 /* PostCreateRequestDTO.swift */; };
+		59D8F1052B103A7200A08E02 /* PostModifyRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D8F1042B103A7200A08E02 /* PostModifyRequestDTO.swift */; };
 		59D8F1072B103F4800A08E02 /* PostCreateUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D8F1062B103F4800A08E02 /* PostCreateUseCase.swift */; };
 		59E0C5FC2AFBA3FC0073D494 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E0C5FB2AFBA3FC0073D494 /* AppDelegate.swift */; };
 		59E0C6052AFBA3FE0073D494 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 59E0C6042AFBA3FE0073D494 /* Assets.xcassets */; };
@@ -155,7 +155,7 @@
 		59D4DBDD2B06889300BBA2D5 /* TimePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePickerView.swift; sourceTree = "<group>"; };
 		59D4DBE12B068C6400BBA2D5 /* UIView+Layer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Layer.swift"; sourceTree = "<group>"; };
 		59D8F1022B0FC4F700A08E02 /* PostCreateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateViewModel.swift; sourceTree = "<group>"; };
-		59D8F1042B103A7200A08E02 /* PostCreateRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateRequestDTO.swift; sourceTree = "<group>"; };
+		59D8F1042B103A7200A08E02 /* PostModifyRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostModifyRequestDTO.swift; sourceTree = "<group>"; };
 		59D8F1062B103F4800A08E02 /* PostCreateUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateUseCase.swift; sourceTree = "<group>"; };
 		59E0C5F82AFBA3FC0073D494 /* Village.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Village.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		59E0C5FB2AFBA3FC0073D494 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -494,7 +494,7 @@
 			children = (
 				4416D4792B15E7E70052BF33 /* Protocol */,
 				4416D4852B171CE50052BF33 /* AppleOAuthDTO.swift */,
-				59D8F1042B103A7200A08E02 /* PostCreateRequestDTO.swift */,
+				59D8F1042B103A7200A08E02 /* PostModifyRequestDTO.swift */,
 				8F1B53352B0E0396006D8982 /* PostListRequestDTO.swift */,
 				8F1B53372B0E03AE006D8982 /* PostListResponseDTO.swift */,
 				44C1F5EC2B0FE44A0047A436 /* UserResponseDTO.swift */,
@@ -937,7 +937,7 @@
 				44C1F5ED2B0FE44A0047A436 /* UserResponseDTO.swift in Sources */,
 				8FD52A4B2B0B0A2F005EE367 /* SearchViewController.swift in Sources */,
 				8F95CF962B0C66910024631F /* Requestable.swift in Sources */,
-				59D8F1052B103A7200A08E02 /* PostCreateRequestDTO.swift in Sources */,
+				59D8F1052B103A7200A08E02 /* PostModifyRequestDTO.swift in Sources */,
 				8F95CF9C2B0C81640024631F /* APIProvider.swift in Sources */,
 				59AABDE12B0E1BB8002F6D0E /* PostCreatePriceView.swift in Sources */,
 				8FC7FE742B05CE9A00B91D3B /* HomeViewModel.swift in Sources */,

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -45,17 +45,25 @@ struct APIEndPoints {
         )
     }
     
-    static func createPost(with requestDTO: PostCreateRequestDTO) -> EndPoint<Void> {
+    static func modifyPost(with requestDTO: PostModifyRequestDTO) -> EndPoint<Void> {
+        
+        var path = "posts"
+        var method = HTTPMethod.POST
+        if let id = requestDTO.postID {
+            path += "/\(id)"
+            method = .PATCH
+        }
+        
         return EndPoint(
             baseURL: baseURL,
-            path: "posts",
-            method: .POST,
+            path: path,
+            method: method,
             bodyParameters: requestDTO.httpBody,
             headers: header?.mergeWith(["Content-Type": "multipart/form-data; boundary=\(requestDTO.boundary)"])
         )
     }
     
-    static func editPost(with requestDTO: PostCreateRequestDTO, postID: Int) -> EndPoint<Void> {
+    static func editPost(with requestDTO: PostModifyRequestDTO, postID: Int) -> EndPoint<Void> {
         return EndPoint(
             baseURL: baseURL,
             path: "posts/\(postID)",

--- a/iOS/Village/Village/Domain/Network/PostModifyRequestDTO.swift
+++ b/iOS/Village/Village/Domain/Network/PostModifyRequestDTO.swift
@@ -1,5 +1,5 @@
 //
-//  PostCreateRequestDTO.swift
+//  PostModifyRequestDTO.swift
 //  Village
 //
 //  Created by 조성민 on 11/24/23.
@@ -7,11 +7,11 @@
 
 import Foundation
 
-struct PostCreateRequestDTO: Encodable, MultipartFormData {
+struct PostModifyRequestDTO: Encodable, MultipartFormData {
     
     let postInfo: PostInfoDTO
     let image: [Data]
-    
+    var postID: Int?
     let boundary = UUID().uuidString
     
     var httpBody: Data {

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreatePriceView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreatePriceView.swift
@@ -88,7 +88,7 @@ final class PostCreatePriceView: UIStackView {
         endEditing(true)
     }
     
-    @objc private func textFieldDidChanged(_ sender: UITextField) {
+    @objc private func textFieldDidChanged() {
         currentPriceSubject.send(priceTextField.text ?? "")
     }
     
@@ -103,6 +103,7 @@ final class PostCreatePriceView: UIStackView {
     
     func setEdit(price: Int?) {
         priceTextField.text = price?.priceText()
+        textFieldDidChanged()
     }
     
 }

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTitleView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTitleView.swift
@@ -93,6 +93,7 @@ final class PostCreateTitleView: UIStackView {
     
     func setEdit(title: String) {
         titleTextField.text = title
+        textFieldDidChanged()
     }
     
 }

--- a/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
@@ -12,7 +12,7 @@ final class PostCreateViewController: UIViewController {
     
     private let viewModel: PostCreateViewModel
     private var postButtonTappedSubject = PassthroughSubject<Void, Never>()
-    var editButtonTappedSubject = PassthroughSubject<PostResponseDTO, Never>()
+    var editButtonTappedSubject = PassthroughSubject<PostResponseDTO?, Never>()
     
     private lazy var keyboardToolBar: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 35))
@@ -190,14 +190,21 @@ final class PostCreateViewController: UIViewController {
         
         output.endResult
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] post in
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    dump(error)
+                }
+            }, receiveValue: { [weak self] post in
                 self?.dismiss(animated: true)
                 self?.navigationController?.popViewController(animated: true)
                 guard let isEdit = self?.viewModel.isEdit else { return }
                 if isEdit {
                     self?.editButtonTappedSubject.send(post)
                 }
-            }
+            })
             .store(in: &cancellableBag)
         
     }

--- a/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
@@ -346,9 +346,17 @@ private extension PostCreateViewController {
     func configureNavigation() {
         let titleLabel = UILabel()
         if viewModel.isRequest {
-            titleLabel.setTitle("대여 요청 등록")
+            if viewModel.isEdit {
+                titleLabel.setTitle("대여 요청 등록 편집")
+            } else {
+                titleLabel.setTitle("대여 요청 등록")
+            }
         } else {
-            titleLabel.setTitle("대여 등록")
+            if viewModel.isEdit {
+                titleLabel.setTitle("대여 등록 편집")
+            } else {
+                titleLabel.setTitle("대여 등록")
+            }
         }
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: titleLabel)
         let close = self.navigationItem.makeSFSymbolButton(

--- a/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
@@ -192,6 +192,7 @@ final class PostCreateViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] post in
                 self?.dismiss(animated: true)
+                self?.navigationController?.popViewController(animated: true)
                 guard let isEdit = self?.viewModel.isEdit else { return }
                 if isEdit {
                     self?.editButtonTappedSubject.send(post)
@@ -218,6 +219,8 @@ final class PostCreateViewController: UIViewController {
 private extension PostCreateViewController {
     
     func close(_ sender: UIBarButtonItem) {
+        
+        navigationController?.popViewController(animated: true)
         dismiss(animated: true)
     }
     

--- a/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
@@ -12,6 +12,7 @@ final class PostCreateViewController: UIViewController {
     
     private let viewModel: PostCreateViewModel
     private var postButtonTappedSubject = PassthroughSubject<Void, Never>()
+    var editButtonTappedSubject = PassthroughSubject<PostResponseDTO, Never>()
     
     private lazy var keyboardToolBar: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 35))
@@ -133,7 +134,7 @@ final class PostCreateViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private var cancellableBag: Set<AnyCancellable> = []
+    var cancellableBag: Set<AnyCancellable> = []
     
     func bind() {
         let input = PostCreateViewModel.Input(
@@ -189,8 +190,12 @@ final class PostCreateViewController: UIViewController {
         
         output.endResult
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] post in
                 self?.dismiss(animated: true)
+                guard let isEdit = self?.viewModel.isEdit else { return }
+                if isEdit {
+                    self?.editButtonTappedSubject.send(post)
+                }
             }
             .store(in: &cancellableBag)
         

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -157,7 +157,6 @@ final class PostCreateViewModel {
                 validate()
                 
                 if isValidPostCreate {
-                    // TODO: doeifhwoighoiawerhgoiqnrgpiqrengpr
                     modifyPost()
                 } else {
                     postButtonTappedTitleWarningOutput.send(isValidTitle)

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -77,6 +77,18 @@ final class PostCreateViewModel {
                 postID: postID
             )
         )
+        Task {
+            do {
+                try await APIProvider.shared.multipartRequest(with: modifyEndPoint)
+                updatePost()
+            } catch let error as NetworkError {
+                self.endOutput.send(completion: .failure(error))
+            }
+        }
+        
+    }
+    
+    func updatePost() {
         guard let id = postID else {
             endOutput.send(nil)
             return
@@ -84,7 +96,6 @@ final class PostCreateViewModel {
         let getPostEndpoint = APIEndPoints.getPost(id: id)
         Task {
             do {
-                try await APIProvider.shared.multipartRequest(with: modifyEndPoint)
                 guard let data = try await APIProvider.shared.request(with: getPostEndpoint) else {
                     self.endOutput.send(nil)
                     return
@@ -94,7 +105,6 @@ final class PostCreateViewModel {
                 self.endOutput.send(completion: .failure(error))
             }
         }
-        
     }
     
     init(useCase: PostCreateUseCase, isRequest: Bool, isEdit: Bool, postID: Int? = nil) {

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -144,6 +144,7 @@ final class PostCreateViewModel {
             .sink { [weak self] () in
                 guard let self = self else { return }
                 validate()
+                
                 if isValidPostCreate {
                     modifyPost()
                     guard let startTime = startTimeInput,

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -160,26 +160,10 @@ final class PostCreateViewModel {
                                 return
                             }
                             self.endOutput.send(data)
-                        } catch let error as NetworkError{
+                        } catch let error as NetworkError {
                             self.endOutput.send(completion: .failure(error))
                         }
                     }
-                    guard let startTime = startTimeInput,
-                          let endTime = endTimeInput else { return }
-                    let startTimeString = formatter.string(from: startTime)
-                    let endTimeString = formatter.string(from: endTime)
-                    endOutput.send(
-                        PostResponseDTO(
-                            title: titleInput,
-                            description: detailInput,
-                            price: priceInput,
-                            userID: "",// TODO: userID 넣어줘야 함.
-                            imageURL: [],
-                            isRequest: isRequest,
-                            startDate: startTimeString,
-                            endDate: endTimeString
-                        )
-                    )
                 } else {
                     postButtonTappedTitleWarningOutput.send(isValidTitle)
                     postButtonTappedStartTimeWarningOutput.send(isValidStartTime)

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -150,8 +150,10 @@ final class PostDetailViewController: UIViewController {
             editVC.editButtonTappedSubject
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] post in
-                    self?.viewModel.postDTO = post
-                    self?.setPostContent(post: post)
+                    guard let fixedPost = post else { return }
+                    self?.viewModel.postDTO = fixedPost
+                    self?.setPostContent(post: fixedPost)
+                    editVC.setEdit(post: fixedPost)
                 }
                 .store(in: &editVC.cancellableBag)
             guard let post = self?.viewModel.postDTO else { return }

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -157,8 +157,17 @@ final class PostDetailViewController: UIViewController {
                 }
                 .store(in: &editVC.cancellableBag)
             guard let post = self?.viewModel.postDTO else { return }
-            editVC.setEdit(post: post)
-            self?.navigationController?.pushViewController(editVC, animated: true)
+            guard let id = self?.postID.output else { return }
+            let endpoint = APIEndPoints.getPost(id: id)
+            Task {
+                do {
+                    guard let data = try await APIProvider.shared.request(with: endpoint) else { return }
+                    editVC.setEdit(post: data)
+                    self?.navigationController?.pushViewController(editVC, animated: true)
+                } catch let error {
+                    dump(error)
+                }
+            }
         }
         
         let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { _ in

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -124,6 +124,12 @@ final class PostDetailViewController: UIViewController {
         bindViewModel()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        guard let postDTO = viewModel.postDTO else { return }
+        setPostContent(post: postDTO)
+    }
+    
     @objc
     private func moreBarButtonTapped() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
@@ -138,6 +144,14 @@ final class PostDetailViewController: UIViewController {
                 postID: self?.postID.output
             )
             let editVC = PostCreateViewController(viewModel: postCreateViewModel)
+            editVC.modalPresentationStyle = .fullScreen
+            editVC.editButtonTappedSubject
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] post in
+                    self?.viewModel.postDTO = post
+                    self?.setPostContent(post: post)
+                }
+                .store(in: &editVC.cancellableBag)
             guard let post = self?.viewModel.postDTO else { return }
             self?.present(editVC, animated: true)
             editVC.setEdit(post: post)

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -128,6 +128,8 @@ final class PostDetailViewController: UIViewController {
         super.viewWillAppear(animated)
         guard let postDTO = viewModel.postDTO else { return }
         setPostContent(post: postDTO)
+        viewModel.postDTO = postDTO
+
     }
     
     @objc
@@ -153,8 +155,9 @@ final class PostDetailViewController: UIViewController {
                 }
                 .store(in: &editVC.cancellableBag)
             guard let post = self?.viewModel.postDTO else { return }
-            self?.present(editVC, animated: true)
             editVC.setEdit(post: post)
+            self?.navigationController?.pushViewController(editVC, animated: true)
+//            self?.present(editNC, animated: true)
         }
         
         let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { _ in

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -153,7 +153,6 @@ final class PostDetailViewController: UIViewController {
                     guard let fixedPost = post else { return }
                     self?.viewModel.postDTO = fixedPost
                     self?.setPostContent(post: fixedPost)
-                    editVC.setEdit(post: fixedPost)
                 }
                 .store(in: &editVC.cancellableBag)
             guard let post = self?.viewModel.postDTO else { return }

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -157,7 +157,6 @@ final class PostDetailViewController: UIViewController {
             guard let post = self?.viewModel.postDTO else { return }
             editVC.setEdit(post: post)
             self?.navigationController?.pushViewController(editVC, animated: true)
-//            self?.present(editNC, animated: true)
         }
         
         let deleteAction = UIAlertAction(title: "삭제하기", style: .destructive) { _ in

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -38,16 +38,7 @@ final class PostDetailViewModel {
             do {
                 guard let data = try await APIProvider.shared.request(with: endpoint) else { return }
                 post.send(data)
-                postDTO = PostResponseDTO(
-                    title: data.title,
-                    description: data.description,
-                    price: data.price,
-                    userID: data.userID,
-                    imageURL: data.imageURL,
-                    isRequest: data.isRequest,
-                    startDate: data.startDate,
-                    endDate: data.endDate
-                )
+                postDTO = data
             } catch let error as NetworkError {
                 post.send(completion: .failure(error))
             }


### PR DESCRIPTION
## 이슈
- #301

## 체크리스트
- [x] 게시글을 수정하고 디테일뷰의 ViewModel의 Post를 다시 받는다.
- [x] ViewModel을 새로고침한다.

## 고민한 내용
- 편집 뷰로 들어갈 때 편집 뷰에 디테일 뷰의 내용을 적어주는 것을  중간에 글의 내용이 변할 수 있다고 판단하여 디테일 뷰에서 가져오지 않고 post id를 이용한 통신을 통해서 가지고 오도록 구현.
- 같은 이유로 편집후 디테일 뷰를 새로고침 해주는 것도 편집 뷰에서 가져오는 것이 아닌 서버에서 가져오도록 구현.

## 스크린샷

![Simulator Screen Recording - iPhone 15 Pro - 2023-12-05 at 19 06 07](https://github.com/boostcampwm2023/iOS05-Village/assets/128480641/a50db286-c8d2-44ec-bbb8-ff683484b09a)

