### PR TITLE
[iOS/#324] 회원 탈퇴 UIAlertController 구현

### DIFF
--- a/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -12,6 +12,7 @@ final class MyPageViewModel {
     
     private var cancellableBag = Set<AnyCancellable>()
     private var logoutSucceed = PassthroughSubject<Void, Error>()
+    private var deleteAccountSucceed = PassthroughSubject<Void, Error>()
     
     func transform(input: Input) -> Output {
         input.logoutSubject
@@ -20,13 +21,24 @@ final class MyPageViewModel {
             })
             .store(in: &cancellableBag)
         
+        input.deleteAccountSubject
+            .sink(receiveValue: { [weak self] in
+                self?.deleteAccount()
+            })
+            .store(in: &cancellableBag)
+        
         return Output(
-            logoutSucceed: logoutSucceed.eraseToAnyPublisher()
+            logoutSucceed: logoutSucceed.eraseToAnyPublisher(),
+            deleteAccountSucceed: deleteAccountSucceed.eraseToAnyPublisher()
         )
     }
     
     private func logout() {
         // TODO: 로그아웃 로직 구현
+    }
+    
+    private func deleteAccount() {
+        // TODO: 회원탈퇴 로직 구현
     }
     
 }
@@ -35,10 +47,12 @@ extension MyPageViewModel {
     
     struct Input {
         var logoutSubject: AnyPublisher<Void, Never>
+        var deleteAccountSubject: AnyPublisher<Void, Never>
     }
     
     struct Output {
         var logoutSucceed: AnyPublisher<Void, Error>
+        var deleteAccountSucceed: AnyPublisher<Void, Error>
     }
     
 }


### PR DESCRIPTION
## 이슈
- #327 

## 체크리스트
- [x] 회원 탈퇴 선택 시 UIAlertController 표시
- [x] ViewModel Input, Output 추가

## 고민한 내용
- 회원탈퇴는 치명적인 동작이므로 style를 destructive로 설정해줬습니다.

## 스크린샷
https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/645335d7-65df-4f24-a4cd-724aa2dc97de
