### PR TITLE
[BE/#322] 검색 구현 및 페이지네이션 수정

### DIFF
--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -1,7 +1,7 @@
 import { HttpException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PostEntity } from '../entities/post.entity';
-import { Repository } from 'typeorm';
+import { Like, Repository } from 'typeorm';
 import { UpdatePostDto } from './dto/postUpdate.dto';
 import { PostImageEntity } from 'src/entities/postImage.entity';
 import { S3Handler } from '../utils/S3Handler';
@@ -9,10 +9,12 @@ import { UserEntity } from '../entities/user.entity';
 import { PostListDto } from './dto/postList.dto';
 import { BlockUserEntity } from '../entities/blockUser.entity';
 import { BlockPostEntity } from '../entities/blockPost.entity';
+import { FindOperator } from 'typeorm/find-options/FindOperator';
 
 interface WhereOption {
   is_request?: boolean;
   user_hash?: string;
+  title?: FindOperator<string>;
 }
 @Injectable()
 export class PostService {
@@ -36,6 +38,9 @@ export class PostService {
     }
     if (query.writer !== undefined) {
       where.user_hash = query.writer;
+    }
+    if (query.searchKeyword !== undefined) {
+      where.title = Like(`%${query.searchKeyword}%`);
     }
     return where;
   }

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -92,7 +92,6 @@ export class PostService {
 
     const posts = await this.postRepository.find({
       take: limit,
-      // skip: offset,
       where: this.makeWhereOption(query),
       relations: ['post_images', 'user'],
       order: {


### PR DESCRIPTION
## 이슈
- #322

## 체크리스트
- [x] 검색 기능 구현
- [x] 페이지네이션 방식을 커서 방식으로 변경 하였다

## 고민한 내용
- 기존 오프셋 방식으로 하면 새로운 게시글이 추가되면 겹치는 문제점이 발생하여 압겹치도록 마지막으로 받은 게시글의 번호를 기준으로 그 아래에 엤는 게시글을 찾는 방식으로 수정하였다.

## 스크린샷
