### PR TITLE
[iOS/#332] 회원 탈퇴 구현

### DIFF
--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -142,5 +142,13 @@ struct APIEndPoints {
             headers: ["Content-Type": "application/json"]
         )
     }
+    
+    static func userDelete(userID: String) -> EndPoint<Void> {
+        EndPoint(
+            baseURL: baseURL,
+            path: "users/\(userID)",
+            method: .DELETE
+        )
+    }
   
 }

--- a/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
@@ -44,6 +44,7 @@ final class JWTManager {
         guard let userID = currentUserID else { return }
         
         try keychainManager.delete(key: userID)
+        UserDefaults.standard.removeObject(forKey: currentUserIDKey)
     }
     
     func update(token: AuthenticationToken) throws {

--- a/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/JWTManager.swift
@@ -14,7 +14,7 @@ final class JWTManager {
     private let keychainManager = KeychainManager<AuthenticationToken>()
     
     private let currentUserIDKey = "currentUserID"
-    private var currentUserID: String? {
+    var currentUserID: String? {
         UserDefaults.standard.string(forKey: currentUserIDKey)
     }
     

--- a/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -38,7 +38,18 @@ final class MyPageViewModel {
     }
     
     private func deleteAccount() {
-        // TODO: 회원탈퇴 로직 구현
+        guard let userID = JWTManager.shared.currentUserID else { return }
+        
+        let endpoint = APIEndPoints.userDelete(userID: userID)
+        Task {
+            do {
+                try await APIProvider.shared.request(with: endpoint)
+                try JWTManager.shared.delete()
+                deleteAccountSucceed.send()
+            } catch let error {
+                deleteAccountSucceed.send(completion: .failure(error))
+            }
+        }
     }
     
 }


### PR DESCRIPTION
## 이슈
- #332

## 체크리스트
- [x] 유저 정보 삭제 API 호출
- [x] Keychain 토큰 삭제 & UserDefaults 유저 아이디 삭제
- [x] 로그인 화면으로 이동

## 고민한 내용
없음

## 스크린샷
https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/5c0b42c0-b305-481f-92cb-6db0225c54ae