### PR TITLE
[iOS/#334] 채팅방에서 상세화면으로 이동

### DIFF
--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -12,7 +12,6 @@ final class ChatRoomViewController: UIViewController {
     
     typealias ChatRoomDataSource = UITableViewDiffableDataSource<Section, Message>
     typealias ViewModel = ChatRoomViewModel
-    typealias Input = ViewModel.Input
     
     private lazy var dataSource: ChatRoomDataSource = ChatRoomDataSource(
         tableView: chatTableView,
@@ -170,12 +169,12 @@ final class ChatRoomViewController: UIViewController {
 private extension ChatRoomViewController {
     
     func bindViewModel() {
-        let output = viewModel.transform(input: ViewModel.Input(roomID: roomID.eraseToAnyPublisher()))
+        let output = viewModel.transformRoom(input: ViewModel.RoomInput(roomID: roomID.eraseToAnyPublisher()))
         
         bindRoomOutput(output)
     }
     
-    func bindRoomOutput(_ output: ViewModel.Output) {
+    func bindRoomOutput(_ output: ViewModel.RoomOutput) {
         output.chatRoom
                     .receive(on: DispatchQueue.main)
                     .sink { completion in

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -247,10 +247,28 @@ private extension ChatRoomViewController {
     }
     
     func setRoomContent(room: GetRoomResponseDTO) {
-        
-//        imageURL = room.postImage
-//        setNavigationTitle(title: room.user)
-//        postView.setContent(url: room.postImage, title: room.postName, price: room.postPrice)
+        let postID = Just(room.postID).eraseToAnyPublisher()
+        let output = viewModel.transformPost(input: ViewModel.PostInput(postID: postID))
+        bindPostOutput(output)
+    }
+    
+    private func bindPostOutput(_ output: ViewModel.PostOutput) {
+        output.post.receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    dump(error)
+                }
+            } receiveValue: { [weak self] post in
+                self?.setPostContent(post: post)
+            }
+            .store(in: &cancellableBag)
+    }
+    
+    private func setPostContent(post: PostResponseDTO) {
+        postView.setContent(url: post.imageURL.first ?? "", title: post.title, price: String(post.price ?? 0))
     }
     
     func generateData() {

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -107,12 +107,18 @@ final class ChatRoomViewController: UIViewController {
         return button
     }()
     
-    private let postView: PostView = {
+    private lazy var postView: PostView = {
         let postView = PostView()
         postView.translatesAutoresizingMaskIntoConstraints = false
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(postViewTapped))
+        postView.addGestureRecognizer(tapGesture)
         
         return postView
     }()
+    
+    @objc private func postViewTapped() {
+        
+    }
     
     init(roomID: Int, opponentNickname: String) {
         self.roomID = Just(roomID)

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -118,14 +118,19 @@ final class ChatRoomViewController: UIViewController {
     }()
     
     @objc private func postViewTapped() {
-        guard let postID = self.postID else { return }
-        postID.sink(receiveValue: { value in
-            let nextVC = PostDetailViewController(postID: value)
-            nextVC.hidesBottomBarWhenPushed = true
-            
-            self.navigationController?.pushViewController(nextVC, animated: true)
-        })
-        .store(in: &cancellableBag)
+        var viewControllers = self.navigationController?.viewControllers ?? []
+        if viewControllers.count > 1 {
+            guard let postID = self.postID else { return }
+            postID.sink(receiveValue: { value in
+                let nextVC = PostDetailViewController(postID: value)
+                nextVC.hidesBottomBarWhenPushed = true
+                
+                self.navigationController?.pushViewController(nextVC, animated: true)
+            })
+            .store(in: &cancellableBag)
+        } else {
+            self.navigationController?.popViewController(animated: true)
+        }
     }
     
     init(roomID: Int, opponentNickname: String) {

--- a/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
@@ -232,9 +232,7 @@ extension HomeViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let post = dataSource.itemIdentifier(for: indexPath) else { return }
         
-        let postDetailVC = PostDetailViewController(postID: post.postID,
-                                                    userID: post.userID,
-                                                    isRequest: post.isRequest)
+        let postDetailVC = PostDetailViewController(postID: post.postID)
         postDetailVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(postDetailVC, animated: true)
     }

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -197,7 +197,12 @@ final class PostDetailViewController: UIViewController {
     @objc
     private func chatButtonTapped() {
         guard let roomID = viewModel.createChatRoom(writer: "qwe", postID: 50149) else { return }
-        pushChatRoomViewController(roomID: roomID.roomID)
+        var viewControllers = self.navigationController?.viewControllers ?? []
+        if viewControllers.count > 1 {
+            self.navigationController?.popViewController(animated: true)
+        } else {
+            pushChatRoomViewController(roomID: roomID.roomID)
+        }
     }
             
     private func pushChatRoomViewController(roomID: Int) {

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -31,20 +31,24 @@ final class PostDetailViewModel {
         return responseData
     }
     
-    func transform(input: Input) -> Output {
+    func transformPost(input: Input) -> Output {
         input.postID
             .sink(receiveValue: { [weak self] id in
                 self?.getPost(id: id)
             })
             .store(in: &cancellableBag)
         
+        return Output(post: post.eraseToAnyPublisher())
+    }
+    
+    func transformUser(input: UserInput) -> UserOutput {
         input.userID
             .sink(receiveValue: { [weak self] id in
                 self?.getUser(id: id)
             })
             .store(in: &cancellableBag)
         
-        return Output(post: post.eraseToAnyPublisher(), user: user.eraseToAnyPublisher())
+        return UserOutput(user: user.eraseToAnyPublisher())
     }
     
     private func getPost(id: Int) {
@@ -80,11 +84,17 @@ extension PostDetailViewModel {
     
     struct Input {
         var postID: AnyPublisher<Int, Never>
-        var userID: AnyPublisher<String, Never>
     }
     
     struct Output {
         var post: AnyPublisher<PostResponseDTO, NetworkError>
+    }
+    
+    struct UserInput {
+        var userID: AnyPublisher<String, Never>
+    }
+    
+    struct UserOutput {
         var user: AnyPublisher<UserResponseDTO, NetworkError>
     }
     


### PR DESCRIPTION
## 이슈
- #334

## 체크리스트
- [x] post_id를 이용해서 API통신 및 뷰 적용
- [x] 클릭 시, 해당 post의 상세페이지로 이동

## 고민한 내용
### PostDetailViewController 인자에 대한 고민
- PostDetailViewController로 넘어갈 때, 기존에는 postID, userID, isRequest 3개의 인자를 받는다
- postID에 나머지 두개가 포함되어있는 것을 확인하고 굳이 3개를 받을 필요를 느끼지 못했다.
- PostDetailViewController의 구조를 변경하고 postID만 가지고도 ViewController를 구현하도록 했다.

### 채팅방 -> 상세화면 -> 채팅하기버튼 무한굴레
- 현재 저런식으로 이동하면 무한대로 push가 됨..

## 스크린샷
![Simulator Screen Recording - iPhone 15 Pro - 2023-12-06 at 13 58 04](https://github.com/boostcampwm2023/iOS05-Village/assets/59719500/393809fc-7eaa-4b60-a566-a8cea108ebe5)

