### PR TITLE
[BE/#322] 도커 적용 및 로그 변경

### DIFF
--- a/BE/.dockerignore
+++ b/BE/.dockerignore
@@ -1,0 +1,5 @@
+/logs
+/node_modules
+/dist
+/coverage
+Dockerfile

--- a/BE/Dockerfile
+++ b/BE/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20
+LABEL authors="koomin"
+RUN mkdir /app
+WORKDIR /app
+COPY . .
+RUN npm install
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "run", "start:prod"]

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -3,10 +3,9 @@ import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { WinstonModule } from 'nest-winston';
 import * as process from 'process';
-import * as winstonDaily from 'winston-daily-rotate-file';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { winstonOptions, dailyOption } from './config/winston.config';
+import { winstonTransportsOption } from './config/winston.config';
 import { MysqlConfigProvider } from './config/mysql.config';
 import { PostModule } from './post/post.module';
 import { APP_PIPE } from '@nestjs/core';
@@ -23,7 +22,7 @@ import { ChatModule } from './chat/chat.module';
       envFilePath: `${process.cwd()}/envs/${process.env.NODE_ENV}.env`,
     }),
     WinstonModule.forRoot({
-      transports: [winstonOptions, new winstonDaily(dailyOption('warn'))],
+      transports: winstonTransportsOption,
     }),
     TypeOrmModule.forRootAsync({
       useClass: MysqlConfigProvider,

--- a/BE/src/config/winston.config.ts
+++ b/BE/src/config/winston.config.ts
@@ -2,7 +2,9 @@ import * as winston from 'winston';
 import {
   utilities as nestWinstonModuleUtilities,
   utilities,
+  WinstonModule,
 } from 'nest-winston';
+import * as winstonDaily from 'winston-daily-rotate-file';
 
 export const winstonOptions = new winston.transports.Console({
   level: process.env.NODE_ENV === 'prod' ? 'http' : 'silly',
@@ -32,3 +34,15 @@ export const dailyOption = (level: string) => {
     ),
   };
 };
+
+export const winstonTransportsOption = [
+  winstonOptions,
+  new winstonDaily(dailyOption('error')),
+  new winstonDaily(dailyOption('warn')),
+  new winstonDaily(dailyOption('info')),
+  new winstonDaily(dailyOption('debug')),
+];
+
+export const winstonLogger = WinstonModule.createLogger({
+  transports: winstonTransportsOption,
+});

--- a/BE/src/main.ts
+++ b/BE/src/main.ts
@@ -1,22 +1,15 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { setupSwagger } from './config/swagger.config';
-import { WINSTON_MODULE_NEST_PROVIDER, WinstonModule } from 'nest-winston';
-import { dailyOption, winstonOptions } from './config/winston.config';
-import * as winstonDaily from 'winston-daily-rotate-file';
+import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
+import { winstonLogger } from './config/winston.config';
 import { ValidationPipe } from '@nestjs/common';
 import { HttpLoggerInterceptor } from './utils/httpLogger.interceptor';
 import { WsAdapter } from '@nestjs/platform-ws';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
-    logger: WinstonModule.createLogger({
-      transports: [
-        winstonOptions,
-        new winstonDaily(dailyOption('error')),
-        new winstonDaily(dailyOption('info')),
-      ],
-    }),
+    logger: winstonLogger,
   });
   app.useGlobalInterceptors(new HttpLoggerInterceptor());
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));


### PR DESCRIPTION
## 이슈
- #322
## 체크리스트
- [x] 도커 적용
- [x] 로그 변경 

## 고민한 내용
- 서버를 분리하기로 결정하였는데 모든 서버 마다 개발 환경을 설치하고 설정하는 것을 번거롭기 때문에 도커로 한번에 처리하기 위해 도커를 적용했다.
- 디버그 레벨의 로그 까지 전부 저장되도록 수정했다.

## 스크린샷
