### PR TITLE
[iOS/#339] 게시글 삭제 구현

### DIFF
--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -72,6 +72,14 @@ struct APIEndPoints {
         )
     }
     
+    static func deletePost(with postID: Int) -> EndPoint<Void> {
+        return EndPoint(
+            baseURL: baseURL,
+            path: "posts/\(postID)",
+            method: .DELETE
+        )
+    }
+    
     static func getChatList(with chatListResponse: ChatListRequestDTO) -> EndPoint<[ChatListResponseDTO]> {
         return EndPoint(
             baseURL: baseURL,


### PR DESCRIPTION
## 이슈
- #339

## 체크리스트
- [x] 자신의 게시글을 삭제할 수 있어야 한다.

## 고민한 내용
- 상세 페이지에서 삭제하기 버튼을 눌렀을 때 삭제요청이 완료되면 상세페이지가 popViewController가 되어야 한다. 그래서 binding을 진행했다.

## 스크린샷
![Simulator Screen Recording - iPhone 15 Pro - 2023-12-07 at 00 34 32](https://github.com/boostcampwm2023/iOS05-Village/assets/128480641/7bfb9bb0-8740-4695-84ab-2afcd41ad70a)


