### PR TITLE
[BE/#358] registration token 삭제 구현

### DIFF
--- a/BE/src/chat/chat.service.ts
+++ b/BE/src/chat/chat.service.ts
@@ -161,7 +161,7 @@ export class ChatService {
       chatRoom.writerUser.user_hash === message.sender
         ? chatRoom.userUser
         : chatRoom.writerUser;
-    const pushMessage: PushMessage = this.fcmHandler.makeChatPushMessage(
+    const pushMessage: PushMessage = this.fcmHandler.createChatPushMessage(
       receiver.nickname,
       message.message,
       message.room_id,

--- a/BE/src/login/login.module.ts
+++ b/BE/src/login/login.module.ts
@@ -6,13 +6,15 @@ import { JwtConfig } from '../config/jwt.config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserEntity } from '../entities/user.entity';
 import { AuthGuard } from 'src/utils/auth.guard';
+import { FcmHandler } from '../utils/fcmHandler';
+import { RegistrationTokenEntity } from '../entities/registrationToken.entity';
 
 @Module({
   imports: [
     JwtModule.registerAsync({ useClass: JwtConfig }),
-    TypeOrmModule.forFeature([UserEntity]),
+    TypeOrmModule.forFeature([UserEntity, RegistrationTokenEntity]),
   ],
   controllers: [LoginController],
-  providers: [LoginService, AuthGuard],
+  providers: [LoginService, AuthGuard, FcmHandler],
 })
 export class LoginModule {}

--- a/BE/src/login/login.service.ts
+++ b/BE/src/login/login.service.ts
@@ -8,6 +8,7 @@ import { hashMaker } from '../utils/hashMaker';
 import { AppleLoginDto } from './dto/appleLogin.dto';
 import * as jwt from 'jsonwebtoken';
 import * as jwksClient from 'jwks-rsa';
+import { FcmHandler } from '../utils/fcmHandler';
 
 export interface SocialProperties {
   OAuthDomain: string;
@@ -24,10 +25,11 @@ export class LoginService {
   private jwksClient: jwksClient.JwksClient;
   private readonly logger = new Logger('ChatsGateway');
   constructor(
-    private jwtService: JwtService,
     @InjectRepository(UserEntity)
     private userRepository: Repository<UserEntity>,
     private configService: ConfigService,
+    private jwtService: JwtService,
+    private fcmHandler: FcmHandler,
   ) {
     this.jwksClient = jwksClient({
       jwksUri: 'https://appleid.apple.com/auth/keys',
@@ -43,8 +45,8 @@ export class LoginService {
     return { access_token: accessToken, refresh_token: refreshToken };
   }
 
-  logout(userId, accessToken) {
-    this.logger.debug(`${userId} ${accessToken}`);
+  async logout(userId, accessToken) {
+    await this.fcmHandler.removeRegistrationToken(userId);
   }
   async registerUser(socialProperties: SocialProperties) {
     const userEntity = new UserEntity();

--- a/BE/src/utils/fcmHandler.ts
+++ b/BE/src/utils/fcmHandler.ts
@@ -18,11 +18,14 @@ export class FcmHandler {
     @InjectRepository(RegistrationTokenEntity)
     private registrationTokenRepository: Repository<RegistrationTokenEntity>,
   ) {
-    admin.initializeApp({
-      credential: admin.credential.cert(
-        this.configService.get('GOOGLE_APPLICATION_CREDENTIALS'),
-      ),
-    });
+    if (admin.apps.length === 0) {
+      admin.initializeApp({
+        credential: admin.credential.cert(
+          this.configService.get('GOOGLE_APPLICATION_CREDENTIALS'),
+        ),
+      });
+      this.logger.log('Firebase Admin initialized');
+    }
   }
 
   async sendPush(userId: string, pushMessage: PushMessage) {

--- a/BE/src/utils/fcmHandler.ts
+++ b/BE/src/utils/fcmHandler.ts
@@ -55,6 +55,7 @@ export class FcmHandler {
       })
       .catch((error) => {
         this.logger.error(error, 'FcmHandler');
+        this.removeRegistrationToken(userId);
       });
   }
 
@@ -66,6 +67,10 @@ export class FcmHandler {
       throw new Error('no registration token');
     }
     return registrationToken.registration_token;
+  }
+
+  async removeRegistrationToken(userId: string) {
+    await this.registrationTokenRepository.delete({ user_hash: userId });
   }
 
   makeChatPushMessage(

--- a/BE/src/utils/fcmHandler.ts
+++ b/BE/src/utils/fcmHandler.ts
@@ -27,23 +27,7 @@ export class FcmHandler {
 
   async sendPush(userId: string, pushMessage: PushMessage) {
     const registrationToken = await this.getRegistrationToken(userId);
-    const message = {
-      token: registrationToken,
-      notification: {
-        title: pushMessage.title,
-        body: pushMessage.body,
-      },
-      apns: {
-        payload: {
-          aps: {
-            sound: 'default',
-          },
-        },
-      },
-      data: {
-        ...pushMessage.data,
-      },
-    };
+    const message = this.createPushMessage(registrationToken, pushMessage);
     admin
       .messaging()
       .send(message)
@@ -71,6 +55,26 @@ export class FcmHandler {
 
   async removeRegistrationToken(userId: string) {
     await this.registrationTokenRepository.delete({ user_hash: userId });
+  }
+
+  createPushMessage(registrationToken: string, pushMessage: PushMessage) {
+    return {
+      token: registrationToken,
+      notification: {
+        title: pushMessage.title,
+        body: pushMessage.body,
+      },
+      apns: {
+        payload: {
+          aps: {
+            sound: 'default',
+          },
+        },
+      },
+      data: {
+        ...pushMessage.data,
+      },
+    };
   }
 
   createChatPushMessage(

--- a/BE/src/utils/fcmHandler.ts
+++ b/BE/src/utils/fcmHandler.ts
@@ -73,7 +73,7 @@ export class FcmHandler {
     await this.registrationTokenRepository.delete({ user_hash: userId });
   }
 
-  makeChatPushMessage(
+  createChatPushMessage(
     nickname: string,
     message: string,
     roomId: number,


### PR DESCRIPTION
## 이슈
- #358

## 체크리스트
- [x] 알림 전송 실패시 토큰 삭제
- [x]  로그아웃시 토큰 삭제 구현

## 고민한 내용
- Injectable 클래스가 싱글톤 인 줄 알았는데 두 개의 모듈에서 사용 해보니 아니었다. firebase admin이 두번 초기화 되서 오류가 떴다. 
- 그래서 한번 초기화 된 다음에는 초기화 되지 않게 수정했다.

## 스크린샷
