### PR TITLE
[iOS/#374] 시간 선택 로직 변경

### DIFF
--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateDetailView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateDetailView.swift
@@ -10,8 +10,6 @@ import Combine
 
 final class PostCreateDetailView: UIStackView {
     
-    var currentDetailSubject = CurrentValueSubject<String, Never>("")
-    
     private let detailHeaderLabel: UILabel = {
         let label = UILabel()
         label.text = "자세한 설명"
@@ -20,7 +18,7 @@ final class PostCreateDetailView: UIStackView {
         return label
     }()
     
-    private lazy var detailTextView: UITextView = {
+    lazy var detailTextView: UITextView = {
         let textView = UITextView()
         textView.setLayer()
         textView.textContainerInset = .init(top: 12, left: 12, bottom: 12, right: 12)
@@ -68,9 +66,6 @@ final class PostCreateDetailView: UIStackView {
         endEditing(true)
     }
     
-    func setEdit(detail: String) {
-        detailTextView.text = detail
-    }
 }
 
 private extension PostCreateDetailView {
@@ -104,7 +99,6 @@ extension PostCreateDetailView: UITextViewDelegate {
                 constraint.constant = estimatedSize.height
             }
         }
-        currentDetailSubject.send(textView.text)
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreatePriceView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreatePriceView.swift
@@ -10,8 +10,6 @@ import Combine
 
 final class PostCreatePriceView: UIStackView {
     
-    var currentPriceSubject = CurrentValueSubject<String, Never>("")
-    
     private lazy var keyboardToolBar: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 35))
         let hideKeyboardButton = UIBarButtonItem(
@@ -40,7 +38,7 @@ final class PostCreatePriceView: UIStackView {
         return label
     }()
     
-    private lazy var priceTextField: UITextField = {
+    lazy var priceTextField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.setLayer()
@@ -57,12 +55,11 @@ final class PostCreatePriceView: UIStackView {
         textField.inputAccessoryView = keyboardToolBar
         textField.delegate = self
         textField.keyboardType = .numberPad
-        textField.addTarget(self, action: #selector(textFieldDidChanged), for: .editingChanged)
         
         return textField
     }()
     
-    private let priceWarningLabel: UILabel = {
+    let priceWarningLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = "하루 대여 가격을 설정해야 합니다."
@@ -88,24 +85,10 @@ final class PostCreatePriceView: UIStackView {
         endEditing(true)
     }
     
-    @objc private func textFieldDidChanged() {
-        currentPriceSubject.send(priceTextField.text ?? "")
-    }
-    
     func warn(_ enable: Bool) {
         let alpha: CGFloat = enable ? 1 : 0
         priceWarningLabel.alpha = alpha
     }
-    
-    func revertChange(text: String) {
-        priceTextField.text = text
-    }
-    
-    func setEdit(price: Int?) {
-        priceTextField.text = price?.priceText()
-        textFieldDidChanged()
-    }
-    
 }
 
 private extension PostCreatePriceView {

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
@@ -36,6 +36,8 @@ final class PostCreateTimeView: UIStackView {
         datePicker.locale = Locale(identifier: PickerLocale.korea.rawValue)
         datePicker.preferredDatePickerStyle = .wheels
         datePicker.datePickerMode = .date
+        datePicker.minimumDate = Date()
+        
         return datePicker
     }()
     
@@ -199,6 +201,15 @@ final class PostCreateTimeView: UIStackView {
         dateTextField.text = dateString
         hourTextField.text = hourString
         setTime()
+    }
+    
+    func changeWarn(enable: Bool) {
+        if enable {
+            timeWarningLabel.text = "종료 시간을 시작 시간보다 늦게 설정해주세요."
+            warn(true)
+        } else {
+            timeWarningLabel.text = "시간을 선택해야 합니다."
+        }
     }
     
 }

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
@@ -21,8 +21,6 @@ enum PickerLocale: String {
 
 final class PostCreateTimeView: UIStackView {
     
-    var currentTimeSubject = CurrentValueSubject<Date?, Never>(nil)
-    
     private let timeStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -60,7 +58,7 @@ final class PostCreateTimeView: UIStackView {
         return toolbar
     }()
     
-    private lazy var dateTextField: UITextField = {
+    lazy var dateTextField: UITextField = {
         let textfield = UITextField()
         textfield.translatesAutoresizingMaskIntoConstraints = false
         textfield.setLayer()
@@ -102,7 +100,7 @@ final class PostCreateTimeView: UIStackView {
         return toolbar
     }()
     
-    private lazy var hourTextField: UITextField = {
+    lazy var hourTextField: UITextField = {
         let textfield = UITextField()
         textfield.translatesAutoresizingMaskIntoConstraints = false
         textfield.setLayer()
@@ -116,7 +114,7 @@ final class PostCreateTimeView: UIStackView {
         
         return textfield
     }()
-
+    
     private var selectedDate: String?
     private var selectedHour: String?
     private let hours = [
@@ -125,10 +123,11 @@ final class PostCreateTimeView: UIStackView {
         "12:00", "13:00", "14:00", "15:00", "16:00", "17:00",
         "18:00", "19:00", "20:00", "21:00", "22:00", "23:00"
     ]
-    var time: Date? {
-        didSet {
-            currentTimeSubject.send(time)
-        }
+    var time: Date?
+    var timeString: String {
+        guard let date = selectedDate,
+              let hour = selectedHour else { return "" }
+        return date + " " + hour
     }
     
     private let isRequest: Bool

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
@@ -183,7 +183,8 @@ final class PostCreateTimeView: UIStackView {
     func setEdit(time: String) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-        guard let timeDate = dateFormatter.date(from: time) else { return }
+        guard var timeDate = dateFormatter.date(from: time) else { return }
+        timeDate -= 540 * 60
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let dateString = dateFormatter.string(from: timeDate)
         dateFormatter.dateFormat = "HH:mm"

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTitleView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTitleView.swift
@@ -10,8 +10,6 @@ import Combine
 
 final class PostCreateTitleView: UIStackView {
     
-    var currentTextSubject = CurrentValueSubject<String, Never>("")
-    
     private lazy var keyboardToolBar: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 35))
         let hideKeyboardButton = UIBarButtonItem(
@@ -40,7 +38,7 @@ final class PostCreateTitleView: UIStackView {
         return label
     }()
     
-    private lazy var titleTextField: UITextField = {
+    lazy var titleTextField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.setLayer()
@@ -51,12 +49,11 @@ final class PostCreateTitleView: UIStackView {
         textField.rightViewMode = .always
         textField.inputAccessoryView = keyboardToolBar
         textField.delegate = self
-        textField.addTarget(self, action: #selector(textFieldDidChanged), for: .editingChanged)
         
         return textField
     }()
     
-    private let titleWarningLabel: UILabel = {
+    let titleWarningLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = "제목을 작성해야 합니다."
@@ -82,18 +79,9 @@ final class PostCreateTitleView: UIStackView {
         endEditing(true)
     }
     
-    @objc private func textFieldDidChanged() {
-        currentTextSubject.send(titleTextField.text ?? "")
-    }
-    
     func warn(_ enable: Bool) {
         let alpha: CGFloat = enable ? 1 : 0
         titleWarningLabel.alpha = alpha
-    }
-    
-    func setEdit(title: String) {
-        titleTextField.text = title
-        textFieldDidChanged()
     }
     
 }

--- a/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
@@ -13,7 +13,7 @@ final class PostCreateViewController: UIViewController {
     private let viewModel: PostCreateViewModel
     var editButtonTappedSubject = PassthroughSubject<Void, Never>()
     private let editSetSubject = PassthroughSubject<Void, Never>()
-    private var postInfoPublisher = PassthroughSubject<PostModifyInfo, Never>()
+    private let postInfoPublisher = PassthroughSubject<PostModifyInfo, Never>()
     
     private lazy var keyboardToolBar: UIToolbar = {
         let toolbar = UIToolbar(frame: CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 35))
@@ -151,10 +151,15 @@ final class PostCreateViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] warning in
                 self?.postCreateTitleView.warn(warning.titleWarning)
-                self?.postCreateStartTimeView.warn(warning.startTimeWarning)
-                self?.postCreateEndTimeView.warn(warning.endTimeWarning)
                 if let priceWarning = warning.priceWarning {
                     self?.postCreatePriceView.warn(priceWarning)
+                }
+                if warning.startTimeWarning || warning.endTimeWarning {
+                    self?.postCreateStartTimeView.warn(warning.startTimeWarning)
+                    self?.postCreateEndTimeView.warn(warning.endTimeWarning)
+                } else {
+                    self?.postCreateStartTimeView.changeWarn(enable: warning.timeSequenceWarning)
+                    self?.postCreateEndTimeView.changeWarn(enable: warning.timeSequenceWarning)
                 }
             }
             .store(in: &cancellableBag)

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -53,6 +53,14 @@ final class PostCreateViewModel {
     }
     
     func modifyPost(post: PostModifyInfo) {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy.MM.dd HH:mm"
+        guard let startTime = dateFormatter.date(from: post.startTime),
+              let endTime = dateFormatter.date(from: post.endTime) else { return }
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        let startTimeString = dateFormatter.string(from: startTime)
+        let endTimeString = dateFormatter.string(from: endTime)
+        
         let modifyEndPoint = APIEndPoints.modifyPost(
             with: PostModifyRequestDTO(
                 postInfo: PostInfoDTO(
@@ -60,8 +68,8 @@ final class PostCreateViewModel {
                     description: post.detail,
                     price: priceToInt(price: post.price),
                     isRequest: isRequest,
-                    startDate: post.startTime,
-                    endDate: post.endTime
+                    startDate: startTimeString,
+                    endDate: endTimeString
                 ),
                 image: [],
                 postID: postID

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -16,8 +16,7 @@ struct PostWarning {
     let priceWarning: Bool?
     
     var validation: Bool {
-        !(titleWarning && startTimeWarning && endTimeWarning && priceWarning == nil ||
-        titleWarning && startTimeWarning && endTimeWarning && priceWarning == true)
+        !(titleWarning || startTimeWarning || endTimeWarning || priceWarning == true)
     }
     
 }
@@ -128,7 +127,7 @@ final class PostCreateViewModel {
                     endTimeWarning: post.endTime.isEmpty,
                     priceWarning: post.price?.isEmpty
                 )
-                if warning.validation {
+                if warning.validation == true {
                     modifyPost(post: post)
                 } else {
                     warningPublisher.send(warning)

--- a/iOS/Village/Village/Presentation/PostDetail/Custom/PostInfoView.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/PostInfoView.swift
@@ -53,11 +53,11 @@ final class PostInfoView: UIView {
     func setContent(title: String, startDate: String, endDate: String, description: String) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-        
+        dateFormatter.timeZone = TimeZone(identifier: "ko_KR")
         titleLabel.text = title
         if let start = dateFormatter.date(from: startDate),
            let end = dateFormatter.date(from: endDate) {
-            durationView.setDuration(from: start, to: end)
+            durationView.setDuration(from: start - 540 * 60, to: end - 540 * 60)
         }
         setDescriptionLabel(description)
     }

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -61,7 +61,7 @@ final class PostDetailViewModel {
         return UserOutput(user: user.eraseToAnyPublisher())
     }
     
-    private func getPost(id: Int) {
+    func getPost(id: Int) {
         let endpoint = APIEndPoints.getPost(id: id)
         
         Task {


### PR DESCRIPTION
## 이슈
- #374

## 체크리스트
- [x] 입력한 시간과 상세페이지에 보여지는 시간을 동일하게 한다.
- [x] 시작시간보다 종료시간이 앞설 수 없다.

## 고민한 내용
- 서버와 상세 페이지의 시간을 일치시키기 위해서 시간을 정수로 9시간을 뻬서 사용한다. 
- 종료시간이 앞선 경우 다른 warning을 띄우도록 설정했다.

## 기타 사항
전반적인 리팩토링을 조금 진행했다. 
비슷한 역할의 Input과 Output을 하나의 struct로 묶어서 보내도록 했다.