### PR TITLE
[BE/#380] 파일 용량 제한 로직 수정

### DIFF
--- a/BE/src/post/post.controller.ts
+++ b/BE/src/post/post.controller.ts
@@ -24,7 +24,7 @@ import { MultiPartBody } from '../utils/multiPartBody.decorator';
 import { PostListDto } from './dto/postList.dto';
 import { AuthGuard } from 'src/utils/auth.guard';
 import { UserHash } from 'src/utils/auth.decorator';
-import { FileSizeValidator } from '../utils/files.validator';
+import { FilesSizeValidator } from '../utils/files.validator';
 
 @Controller('posts')
 @ApiTags('posts')
@@ -41,7 +41,7 @@ export class PostController {
   @Post()
   @UseInterceptors(FilesInterceptor('image', 12))
   async postsCreate(
-    @UploadedFiles(new FileSizeValidator())
+    @UploadedFiles(new FilesSizeValidator())
     files: Array<Express.Multer.File>,
     @MultiPartBody(
       'post_info',
@@ -68,7 +68,7 @@ export class PostController {
   @UseInterceptors(FilesInterceptor('image', 12))
   async postModify(
     @Param('id') id: number,
-    @UploadedFiles(new FileSizeValidator())
+    @UploadedFiles(new FilesSizeValidator())
     files: Array<Express.Multer.File>,
     @MultiPartBody(
       'post_info',

--- a/BE/src/users/users.controller.ts
+++ b/BE/src/users/users.controller.ts
@@ -41,11 +41,7 @@ export class UsersController {
   @Post()
   @UseInterceptors(FileInterceptor('profileImage'))
   async usersCreate(
-    @UploadedFile(
-      new ParseFilePipe({
-        validators: [new MaxFileSizeValidator({ maxSize: 1024 * 1024 * 20 })],
-      }),
-    )
+    @UploadedFile(new FileSizeValidator())
     file: Express.Multer.File,
     @MultiPartBody(
       'profile',

--- a/BE/src/utils/files.validator.ts
+++ b/BE/src/utils/files.validator.ts
@@ -6,9 +6,9 @@ import {
 } from '@nestjs/common';
 
 @Injectable()
-export class FileSizeValidator implements PipeTransform {
+export class FilesSizeValidator implements PipeTransform {
   transform(value: any, metadata: ArgumentMetadata): any {
-    if (value === undefined || value.length === 0) {
+    if (value.length === 0) {
       return value;
     }
     const maxSize = 1024 * 1024 * 20;
@@ -20,6 +20,22 @@ export class FileSizeValidator implements PipeTransform {
         );
       }
     }
-    return undefined;
+    return value;
+  }
+}
+
+export class FileSizeValidator implements PipeTransform {
+  transform(value: any, metadata: ArgumentMetadata): any {
+    if (value === undefined) {
+      return value;
+    }
+    const maxSize = 1024 * 1024 * 20;
+    const file: Express.Multer.File = value;
+    if (file.size > maxSize) {
+      throw new BadRequestException(
+        `File ${file.originalname} exceeds the allowed size limit`,
+      );
+    }
+    return value;
   }
 }


### PR DESCRIPTION
## 이슈
- #380

## 체크리스트
- [x] 파일 용량 제한 로직 수정

## 고민한 내용
- 파일 하나당 20메가로 제한
- nginx 에서 기본으로 요청 크기 제한을 두고 있어 50메가 정도 넘어가면 막혀서 나중에 수정이 필요할 것 같다.
