### PR TITLE
[iOS/#384] 프로필 수정 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		59110EFB2B15F3D60009E9AC /* ChatRoomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110EFA2B15F3D60009E9AC /* ChatRoomTableViewCell.swift */; };
 		59110EFD2B15F5340009E9AC /* UITableViewCell+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110EFC2B15F5340009E9AC /* UITableViewCell+Identifier.swift */; };
 		59110F042B1725C20009E9AC /* NotificationName+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110F032B1725C20009E9AC /* NotificationName+.swift */; };
+		59457BC72B233EE5003F798C /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59457BC62B233EE5003F798C /* UIImage+Resize.swift */; };
 		5975E98A2B035919007CEF13 /* Post.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9872B035919007CEF13 /* Post.json */; };
 		5975E98B2B035919007CEF13 /* Posts.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9882B035919007CEF13 /* Posts.json */; };
 		5975E98C2B035919007CEF13 /* Users.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9892B035919007CEF13 /* Users.json */; };
@@ -158,6 +159,7 @@
 		59110EFC2B15F5340009E9AC /* UITableViewCell+Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Identifier.swift"; sourceTree = "<group>"; };
 		59110F022B1714BE0009E9AC /* Village.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Village.entitlements; sourceTree = "<group>"; };
 		59110F032B1725C20009E9AC /* NotificationName+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+.swift"; sourceTree = "<group>"; };
+		59457BC62B233EE5003F798C /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
 		5975E9872B035919007CEF13 /* Post.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Post.json; sourceTree = "<group>"; };
 		5975E9882B035919007CEF13 /* Posts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Posts.json; sourceTree = "<group>"; };
 		5975E9892B035919007CEF13 /* Users.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Users.json; sourceTree = "<group>"; };
@@ -756,6 +758,7 @@
 				8F3D79E52B1469DF00370536 /* UICollectionViewCell+Identifier.swift */,
 				59110EFC2B15F5340009E9AC /* UITableViewCell+Identifier.swift */,
 				59110F032B1725C20009E9AC /* NotificationName+.swift */,
+				59457BC62B233EE5003F798C /* UIImage+Resize.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1014,6 +1017,7 @@
 				8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */,
 				8F1B53382B0E03AE006D8982 /* PostListResponseDTO.swift in Sources */,
 				4416D48C2B174C7A0052BF33 /* KeychainManager.swift in Sources */,
+				59457BC72B233EE5003F798C /* UIImage+Resize.swift in Sources */,
 				5980D75F2B0FB6DB00A6B370 /* PostCreateRepository.swift in Sources */,
 				4416D48E2B174CBA0052BF33 /* KeychainError.swift in Sources */,
 				4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		59110EFD2B15F5340009E9AC /* UITableViewCell+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110EFC2B15F5340009E9AC /* UITableViewCell+Identifier.swift */; };
 		59110F042B1725C20009E9AC /* NotificationName+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110F032B1725C20009E9AC /* NotificationName+.swift */; };
 		59457BC72B233EE5003F798C /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59457BC62B233EE5003F798C /* UIImage+Resize.swift */; };
+		59457BC92B237615003F798C /* PatchUserDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59457BC82B237615003F798C /* PatchUserDTO.swift */; };
 		5975E98A2B035919007CEF13 /* Post.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9872B035919007CEF13 /* Post.json */; };
 		5975E98B2B035919007CEF13 /* Posts.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9882B035919007CEF13 /* Posts.json */; };
 		5975E98C2B035919007CEF13 /* Users.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9892B035919007CEF13 /* Users.json */; };
@@ -160,6 +161,7 @@
 		59110F022B1714BE0009E9AC /* Village.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Village.entitlements; sourceTree = "<group>"; };
 		59110F032B1725C20009E9AC /* NotificationName+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+.swift"; sourceTree = "<group>"; };
 		59457BC62B233EE5003F798C /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
+		59457BC82B237615003F798C /* PatchUserDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchUserDTO.swift; sourceTree = "<group>"; };
 		5975E9872B035919007CEF13 /* Post.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Post.json; sourceTree = "<group>"; };
 		5975E9882B035919007CEF13 /* Posts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Posts.json; sourceTree = "<group>"; };
 		5975E9892B035919007CEF13 /* Users.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Users.json; sourceTree = "<group>"; };
@@ -582,6 +584,7 @@
 				8F8F0B842B1C7A5800BE97D2 /* ChatRoomRequestDTO.swift */,
 				8F8F0B8E2B1DB2EE00BE97D2 /* PostMuteResponseDTO.swift */,
 				8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */,
+				59457BC82B237615003F798C /* PatchUserDTO.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1036,6 +1039,7 @@
 				8FBE3B0A2B0478D400660530 /* HomeCollectionViewCell.swift in Sources */,
 				59AABDE52B0E2D47002F6D0E /* PostCreateDetailView.swift in Sources */,
 				4461F39D2B1786DA00723C55 /* JWTManager.swift in Sources */,
+				59457BC92B237615003F798C /* PatchUserDTO.swift in Sources */,
 				440FCC2D2B04EB940011B637 /* Constants.swift in Sources */,
 				8F3D79E62B1469DF00370536 /* UICollectionViewCell+Identifier.swift in Sources */,
 				444A50982B0CE25200454397 /* DurationView.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		59AABDE12B0E1BB8002F6D0E /* PostCreatePriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */; };
 		59AABDE32B0E272C002F6D0E /* PostCreateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */; };
 		59AABDE52B0E2D47002F6D0E /* PostCreateDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */; };
+		59AADE382B22086400C3E17D /* SignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AADE372B22086400C3E17D /* SignUpViewModel.swift */; };
 		59B6E2732B17938C000864F9 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B6E2722B17938C000864F9 /* MyPageViewModel.swift */; };
 		59B6E27C2B185FD2000864F9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 59B6E27B2B185FD2000864F9 /* GoogleService-Info.plist */; };
 		59B6E27F2B18604D000864F9 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 59B6E27E2B18604D000864F9 /* FirebaseAnalytics */; };
@@ -167,6 +168,7 @@
 		59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreatePriceView.swift; sourceTree = "<group>"; };
 		59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateTimeView.swift; sourceTree = "<group>"; };
 		59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateDetailView.swift; sourceTree = "<group>"; };
+		59AADE372B22086400C3E17D /* SignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewModel.swift; sourceTree = "<group>"; };
 		59B6E2722B17938C000864F9 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		59B6E27B2B185FD2000864F9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		59BA10F92B1CC3F700F30DB8 /* FCMManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMManager.swift; sourceTree = "<group>"; };
@@ -265,6 +267,7 @@
 		4416D44D2B14A4260052BF33 /* SignUp */ = {
 			isa = PBXGroup;
 			children = (
+				59AADE362B22085500C3E17D /* ViewModel */,
 				4416D44E2B14A4310052BF33 /* View */,
 			);
 			path = SignUp;
@@ -419,6 +422,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		59AADE362B22085500C3E17D /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				59AADE372B22086400C3E17D /* SignUpViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		59B6E26F2B17931F000864F9 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -568,7 +579,6 @@
 				8F1E2CED2B1F163D00179E34 /* GetRoomResponseDTO.swift */,
 				8F8F0B842B1C7A5800BE97D2 /* ChatRoomRequestDTO.swift */,
 				8F8F0B8E2B1DB2EE00BE97D2 /* PostMuteResponseDTO.swift */,
-				59E6A20C2B1F865700A2DF21 /* GetPostsQueryDTO.swift */,
 				8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */,
 			);
 			path = Network;
@@ -1055,6 +1065,7 @@
 				59D8F1072B103F4800A08E02 /* PostCreateUseCase.swift in Sources */,
 				8F8F0B8B2B1D985A00BE97D2 /* BlockedUserViewController.swift in Sources */,
 				8F8F0B8D2B1DA91500BE97D2 /* PostMuteTableViewCell.swift in Sources */,
+				59AADE382B22086400C3E17D /* SignUpViewModel.swift in Sources */,
 				8FBB65CC2B20587B00C6A133 /* BlockedUserTableViewCell.swift in Sources */,
 				446362CB2B0DFD4F00B74DA7 /* Int+.swift in Sources */,
 				5979BA7C2B08AE3C00FFF215 /* UITextField+.swift in Sources */,

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -173,5 +173,15 @@ struct APIEndPoints {
             method: .POST
         )
     }
-  
+    
+    static func patchUser(userInfo: PatchUserDTO) -> EndPoint<Void> {
+        return EndPoint(
+            baseURL: baseURL,
+            path: "users/\(userInfo.userID)",
+            method: .PATCH,
+            bodyParameters: userInfo.httpBody,
+            headers: ["Content-Type": "multipart/form-data; boundary=\(userInfo.boundary)"]
+        )
+    }
+    
 }

--- a/iOS/Village/Village/Data/PersistentStorage/FCMManager.swift
+++ b/iOS/Village/Village/Data/PersistentStorage/FCMManager.swift
@@ -31,7 +31,7 @@ final class FCMManager {
             let endPoint = APIEndPoints.fcmTokenSend(fcmToken: token)
             Task {
                 do {
-                    let _ = try await APIProvider.shared.request(with: endPoint)
+                    try await APIProvider.shared.request(with: endPoint)
                 }
             }
         }

--- a/iOS/Village/Village/Domain/Network/PatchUserDTO.swift
+++ b/iOS/Village/Village/Domain/Network/PatchUserDTO.swift
@@ -1,0 +1,48 @@
+//
+//  PatchUserDTO.swift
+//  Village
+//
+//  Created by 조성민 on 12/9/23.
+//
+
+import Foundation
+
+struct PatchUserInfo: Encodable {
+    let nickname: String?
+}
+
+struct PatchUserDTO: Encodable, MultipartFormData {
+    
+    let userInfo: PatchUserInfo?
+    let image: Data?
+    let userID: String
+    var boundary: String = UUID().uuidString
+    var httpBody: Data {
+        let body = NSMutableData()
+        
+        var fieldString = ""
+        if let dictionary = try? userInfo.toDictionary(),
+           !dictionary.isEmpty,
+           let data = try? JSONSerialization.data(withJSONObject: dictionary),
+           let string = String(data: data, encoding: .utf8) {
+            fieldString += "--\(boundary)\r\n"
+            fieldString += "Content-Disposition: form-data; name=\"profile\"\r\n"
+            fieldString += "\r\n"
+            fieldString += "\(string)\r\n"
+        }
+        
+        body.appendString(fieldString)
+        
+        if let image = image {
+            body.appendString("--\(boundary)\r\n")
+            body.appendString("Content-Disposition: form-data; name=\"image\"; filename=\"image.png\"\r\n")
+            body.appendString("Content-Type: image\r\n\r\n")
+            body.append(image)
+            body.appendString("\r\n")
+        }
+        body.appendString("--\(boundary)--")
+        
+        return body as Data
+    }
+    
+}

--- a/iOS/Village/Village/Domain/Network/PostModifyRequestDTO.swift
+++ b/iOS/Village/Village/Domain/Network/PostModifyRequestDTO.swift
@@ -15,7 +15,7 @@ struct PostModifyRequestDTO: Encodable, MultipartFormData {
     let boundary = UUID().uuidString
     
     var httpBody: Data {
-        var body = NSMutableData()
+        let body = NSMutableData()
         
         var fieldString = "--\(boundary)\r\n"
         fieldString += "Content-Disposition: form-data; name=\"post_info\"\r\n"

--- a/iOS/Village/Village/Domain/Network/PostModifyRequestDTO.swift
+++ b/iOS/Village/Village/Domain/Network/PostModifyRequestDTO.swift
@@ -69,7 +69,7 @@ struct PostInfoDTO: Encodable {
     
 }
 
-private extension NSMutableData {
+extension NSMutableData {
     
     func appendString(_ string: String) {
         if let data = string.data(using: .utf8) {

--- a/iOS/Village/Village/Network/APIProvider/APIProvider.swift
+++ b/iOS/Village/Village/Network/APIProvider/APIProvider.swift
@@ -25,6 +25,7 @@ final class APIProvider: Provider {
         self.interceptor = interceptor
     }
     
+    @discardableResult
     func request<R: Decodable, E: Requestable&Responsable>(with endpoint: E) async throws -> R? where E.Response == R {
         guard let data = try await sendRequest(with: endpoint) else { return nil }
         

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -187,7 +187,7 @@ private extension ChatRoomViewController {
     }
     
     @objc private func postViewTapped() {
-        var viewControllers = self.navigationController?.viewControllers ?? []
+        let viewControllers = self.navigationController?.viewControllers ?? []
         if viewControllers.count > 1 {
             guard let postID = self.postID else { return }
             postID.sink(receiveValue: { value in

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -313,6 +313,25 @@ private extension MyPageViewController {
                 NotificationCenter.default.post(Notification(name: .shouldLogin))
             }
             .store(in: &cancellableBag)
+        
+        output.nicknameOutput
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] nickname in
+                self?.nicknameLabel.text = nickname
+                guard let userID = JWTManager.shared.currentUserID else { return }
+                self?.hashIDLabel.text = "#" + userID
+            }
+            .store(in: &cancellableBag)
+        
+        output.profileImageDataOutput
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] profileImageData in
+                guard let data = profileImageData,
+                      let image = UIImage(data: data) else { return }
+                self?.profileImageView.image = image
+            }
+            .store(in: &cancellableBag)
+        
     }
     
 }

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -338,6 +338,12 @@ private extension MyPageViewController {
             profileInfo: postInfo
         ))
         nextVC.hidesBottomBarWhenPushed = true
+        nextVC.updateSuccessSubject
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.viewModel.getUserInfo()
+            }
+            .store(in: &cancellableBag)
         self.navigationController?.pushViewController(nextVC, animated: true)
     }
     

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -340,7 +340,10 @@ private extension MyPageViewController {
 private extension MyPageViewController {
     
     func profileEditButtonTapped() {
-        let nextVC = SignUpViewController(viewModel: SignUpViewModel())
+        let nextVC = SignUpViewController(viewModel: SignUpViewModel(
+            profileImageData: viewModel.profileImageDataSubject.value,
+            nickname: viewModel.nicknameSubject.value
+        ))
         nextVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(nextVC, animated: true)
     }

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -25,6 +25,7 @@ final class MyPageViewController: UIViewController {
         imageView.tintColor = .primary500
         imageView.setLayer(borderWidth: 0, cornerRadius: 16)
         imageView.backgroundColor = .primary100
+        imageView.clipsToBounds = true
         
         return imageView
     }()
@@ -86,7 +87,6 @@ final class MyPageViewController: UIViewController {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
-        stackView.spacing = 10
         stackView.alignment = .leading
         
         return stackView
@@ -236,7 +236,9 @@ private extension MyPageViewController {
         
         view.addSubview(profileStackView)
         profileStackView.addArrangedSubview(nicknameLabel)
+        profileStackView.setCustomSpacing(2, after: nicknameLabel)
         profileStackView.addArrangedSubview(hashIDLabel)
+        profileStackView.setCustomSpacing(6, after: hashIDLabel)
         profileStackView.addArrangedSubview(profileEditButton)
         
         view.addSubview(activityStackView)

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -22,7 +22,6 @@ final class MyPageViewController: UIViewController {
     private let profileImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.image = UIImage(systemName: ImageSystemName.personFill.rawValue)
         imageView.tintColor = .primary500
         imageView.setLayer(borderWidth: 0, cornerRadius: 16)
         imageView.backgroundColor = .primary100
@@ -34,7 +33,6 @@ final class MyPageViewController: UIViewController {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
-        label.text = "닉네임"
         
         return label
     }()
@@ -43,7 +41,6 @@ final class MyPageViewController: UIViewController {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = UIFont.systemFont(ofSize: 16)
-        label.text = "#123123"
         label.textColor = .secondaryLabel
         
         return label
@@ -81,6 +78,16 @@ final class MyPageViewController: UIViewController {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.spacing = 10
+        
+        return stackView
+    }()
+    
+    private let profileStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        stackView.alignment = .leading
         
         return stackView
     }()
@@ -226,17 +233,19 @@ private extension MyPageViewController {
     
     func setUI() {
         view.addSubview(profileImageView)
-        view.addSubview(nicknameLabel)
-        view.addSubview(hashIDLabel)
-        view.addSubview(profileEditButton)
-        view.addSubview(activityStackView)
-        view.addSubview(accountStackView)
         
+        view.addSubview(profileStackView)
+        profileStackView.addArrangedSubview(nicknameLabel)
+        profileStackView.addArrangedSubview(hashIDLabel)
+        profileStackView.addArrangedSubview(profileEditButton)
+        
+        view.addSubview(activityStackView)
         activityStackView.addArrangedSubview(activityLabel)
         activityStackView.addArrangedSubview(myPostButton)
         activityStackView.addArrangedSubview(hiddenPostButton)
         activityStackView.addArrangedSubview(hiddenUserButton)
         
+        view.addSubview(accountStackView)
         accountStackView.addArrangedSubview(accountLabel)
         accountStackView.addArrangedSubview(logoutButton)
         accountStackView.addArrangedSubview(deleteAccountButton)
@@ -252,18 +261,8 @@ private extension MyPageViewController {
         ])
         
         NSLayoutConstraint.activate([
-            nicknameLabel.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: 15),
-            nicknameLabel.bottomAnchor.constraint(equalTo: profileImageView.centerYAnchor, constant: -5)
-        ])
-        
-        NSLayoutConstraint.activate([
-            hashIDLabel.leadingAnchor.constraint(equalTo: nicknameLabel.trailingAnchor, constant: 5),
-            hashIDLabel.bottomAnchor.constraint(equalTo: nicknameLabel.bottomAnchor)
-        ])
-        
-        NSLayoutConstraint.activate([
-            profileEditButton.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: 15),
-            profileEditButton.topAnchor.constraint(equalTo: profileImageView.centerYAnchor, constant: 5)
+            profileStackView.leadingAnchor.constraint(equalTo: profileImageView.trailingAnchor, constant: 15),
+            profileStackView.centerYAnchor.constraint(equalTo: profileImageView.centerYAnchor, constant: 0)
         ])
         
         NSLayoutConstraint.activate([

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -321,7 +321,9 @@ private extension MyPageViewController {
 private extension MyPageViewController {
     
     func profileEditButtonTapped() {
-        
+        let nextVC = SignUpViewController(viewModel: SignUpViewModel())
+        nextVC.hidesBottomBarWhenPushed = true
+        self.navigationController?.pushViewController(nextVC, animated: true)
     }
     
     func myPostsButtonTapped() {

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -314,24 +314,17 @@ private extension MyPageViewController {
             }
             .store(in: &cancellableBag)
         
-        output.nicknameOutput
+        output.profileInfoOutput
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] nickname in
-                self?.nicknameLabel.text = nickname
+            .sink { [weak self] profileInfo in
+                guard let data = profileInfo?.profileImage,
+                      let image = UIImage(data: data) else { return }
+                self?.profileImageView.image = image
+                self?.nicknameLabel.text = profileInfo?.nickname
                 guard let userID = JWTManager.shared.currentUserID else { return }
                 self?.hashIDLabel.text = "#" + userID
             }
             .store(in: &cancellableBag)
-        
-        output.profileImageDataOutput
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] profileImageData in
-                guard let data = profileImageData,
-                      let image = UIImage(data: data) else { return }
-                self?.profileImageView.image = image
-            }
-            .store(in: &cancellableBag)
-        
     }
     
 }
@@ -340,9 +333,9 @@ private extension MyPageViewController {
 private extension MyPageViewController {
     
     func profileEditButtonTapped() {
+        guard let postInfo = viewModel.profileInfoSubject.value else { return }
         let nextVC = SignUpViewController(viewModel: SignUpViewModel(
-            profileImageData: viewModel.profileImageDataSubject.value,
-            nickname: viewModel.nicknameSubject.value
+            profileInfo: postInfo
         ))
         nextVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(nextVC, animated: true)

--- a/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Combine
 
-struct ProfileInfo {
+struct ProfileInfo: Equatable {
     
     var nickname: String
     var profileImage: Data?

--- a/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -13,14 +13,14 @@ final class MyPageViewModel {
     private var cancellableBag = Set<AnyCancellable>()
     private var logoutSucceed = PassthroughSubject<Void, Error>()
     private var deleteAccountSucceed = PassthroughSubject<Void, Error>()
-    private var nicknameSubject = CurrentValueSubject<String, Never>("")
-    private var profileImageDataSubject = CurrentValueSubject<Data?, Never>(nil)
+    var nicknameSubject = CurrentValueSubject<String, Never>("")
+    var profileImageDataSubject = CurrentValueSubject<Data?, Never>(nil)
     
     init() {
         getUserInfo()
     }
     
-    private func getUserInfo() {
+    func getUserInfo() {
         guard let userID = JWTManager.shared.currentUserID else { return }
         let endpoint = APIEndPoints.getUser(id: userID)
         

--- a/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyPage/ViewModel/MyPageViewModel.swift
@@ -10,8 +10,8 @@ import Combine
 
 struct ProfileInfo {
     
-    let nickname: String
-    let profileImage: Data?
+    var nickname: String
+    var profileImage: Data?
     
 }
 

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
@@ -185,7 +185,7 @@ final class PostCreateTimeView: UIStackView {
     func setEdit(time: String) {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-        guard var timeDate = dateFormatter.date(from: time) else { return }
+        guard let timeDate = dateFormatter.date(from: time) else { return }
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let dateString = dateFormatter.string(from: timeDate)
         dateFormatter.dateFormat = "HH:mm"

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/PostCreateTimeView.swift
@@ -186,7 +186,6 @@ final class PostCreateTimeView: UIStackView {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
         guard var timeDate = dateFormatter.date(from: time) else { return }
-        timeDate -= 540 * 60
         dateFormatter.dateFormat = "yyyy-MM-dd"
         let dateString = dateFormatter.string(from: timeDate)
         dateFormatter.dateFormat = "HH:mm"

--- a/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
@@ -158,7 +158,6 @@ final class PostCreateViewController: UIViewController {
                     self?.postCreateStartTimeView.warn(warning.startTimeWarning)
                     self?.postCreateEndTimeView.warn(warning.endTimeWarning)
                 } else {
-                    self?.postCreateStartTimeView.changeWarn(enable: warning.timeSequenceWarning)
                     self?.postCreateEndTimeView.changeWarn(enable: warning.timeSequenceWarning)
                 }
             }

--- a/iOS/Village/Village/Presentation/PostDetail/Custom/PostInfoView.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/PostInfoView.swift
@@ -57,7 +57,7 @@ final class PostInfoView: UIView {
         titleLabel.text = title
         if let start = dateFormatter.date(from: startDate),
            let end = dateFormatter.date(from: endDate) {
-            durationView.setDuration(from: start - 540 * 60, to: end - 540 * 60)
+            durationView.setDuration(from: start, to: end)
         }
         setDescriptionLabel(description)
     }

--- a/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
@@ -35,6 +35,7 @@ final class NicknameTextField: UIView {
         textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         textField.leftViewMode = .always
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
+        textField.delegate = self
         textField.setLayer(borderColor: .systemGray4)
         
         return textField
@@ -79,6 +80,21 @@ private extension NicknameTextField {
         ])
         
         textField.heightAnchor.constraint(equalToConstant: 45).isActive = true
+    }
+    
+}
+
+extension NicknameTextField: UITextFieldDelegate {
+    
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        
+        guard let text = textField.text else { return false }
+        
+        if text.count + string.count > 10 {
+            return false
+        }
+        
+        return true
     }
     
 }

--- a/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
@@ -32,7 +32,7 @@ final class NicknameTextField: UIView {
     private lazy var textField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.addTarget(self, action: #selector(textFieldDidChange), for: .valueChanged)
+        textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         textField.leftViewMode = .always
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
         textField.setLayer(borderColor: .systemGray4)

--- a/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
@@ -9,6 +9,8 @@ import UIKit
 import Combine
 
 final class NicknameTextField: UIView {
+    
+    var nicknameText = PassthroughSubject<String, Never>()
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
@@ -27,9 +29,10 @@ final class NicknameTextField: UIView {
         return label
     }()
     
-    lazy var textField: UITextField = {
+    private lazy var textField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
+        textField.addTarget(self, action: #selector(textFieldDidChange), for: .valueChanged)
         textField.leftViewMode = .always
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
         textField.setLayer(borderColor: .systemGray4)
@@ -46,6 +49,15 @@ final class NicknameTextField: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("should not be called")
+    }
+    
+    @objc
+    private func textFieldDidChange() {
+        nicknameText.send(textField.text ?? "")
+    }
+    
+    func setNickname(nickname: String?) {
+        textField.text = nickname
     }
 
 }

--- a/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/Custom/NicknameTextField.swift
@@ -9,8 +9,6 @@ import UIKit
 import Combine
 
 final class NicknameTextField: UIView {
-    
-    var nicknameText = PassthroughSubject<String, Never>()
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
@@ -29,10 +27,9 @@ final class NicknameTextField: UIView {
         return label
     }()
     
-    private lazy var textField: UITextField = {
+    lazy var textField: UITextField = {
         let textField = UITextField()
         textField.translatesAutoresizingMaskIntoConstraints = false
-        textField.addTarget(self, action: #selector(textFieldDidChange), for: .valueChanged)
         textField.leftViewMode = .always
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 0))
         textField.setLayer(borderColor: .systemGray4)
@@ -49,11 +46,6 @@ final class NicknameTextField: UIView {
     
     required init?(coder: NSCoder) {
         fatalError("should not be called")
-    }
-    
-    @objc
-    private func textFieldDidChange() {
-        nicknameText.send(textField.text ?? "")
     }
 
 }

--- a/iOS/Village/Village/Presentation/SignUp/View/Custom/ProfileImageView.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/Custom/ProfileImageView.swift
@@ -43,6 +43,10 @@ final class ProfileImageView: UIView {
     required init?(coder: NSCoder) {
         fatalError("should not be called")
     }
+    
+    func setProfile(image: UIImage) {
+        profileImageView.image = image
+    }
 
 }
 

--- a/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
@@ -17,6 +17,7 @@ final class SignUpViewController: UIViewController {
     
     private let nicknameSubject = PassthroughSubject<String, Never>()
     private let profileImageDataSubject = PassthroughSubject<Data?, Never>()
+    private let completeButtonSubject = PassthroughSubject<Void, Never>()
     private var cancellableBag = Set<AnyCancellable>()
     
     private lazy var profileImageView: ProfileImageView = {
@@ -101,13 +102,22 @@ private extension SignUpViewController {
     func bindViewModel() {
         let output = viewModel.transform(input: ViewModel.Input(
             nicknameInput: nicknameSubject,
-            profileImageDataInput: profileImageDataSubject
+            profileImageDataInput: profileImageDataSubject,
+            completeButtonSubject: completeButtonSubject
         ))
         
-        output.completeButtonOutput
+        output.completeButtonEnableOutput
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isEnable in
                 self?.completeButton.isEnabled = isEnable
+            }
+            .store(in: &cancellableBag)
+        
+        output.completeButtonOutput
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] in
+                self?.dismiss(animated: true)
+                // TODO: 마이페이지 새로고침
             }
             .store(in: &cancellableBag)
         
@@ -136,7 +146,7 @@ private extension SignUpViewController {
 extension SignUpViewController {
     
     func completeButtonTapped() {
-        dump("Complete Button Tapped")
+        completeButtonSubject.send()
     }
     
     func imageClicked() {

--- a/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
@@ -114,7 +114,9 @@ extension SignUpViewController: PHPickerViewControllerDelegate {
         guard let result = results.first else { return }
         result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] (image, _) in
             guard let image = image as? UIImage else { return }
-            self?.profileImageView.setProfile(image: image)
+            DispatchQueue.main.async {
+                self?.profileImageView.setProfile(image: image)
+            }
         }
     }
     

--- a/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
@@ -9,21 +9,9 @@ import UIKit
 
 final class SignUpViewController: UIViewController {
     
-    private lazy var navigationBar: UINavigationBar = {
-        let bar = UINavigationBar()
-        bar.translatesAutoresizingMaskIntoConstraints = false
-        bar.tintColor = .label
-        
-        return bar
-    }()
+    typealias ViewModel = SignUpViewModel
     
-    private lazy var doneButton: UIBarButtonItem = {
-        let button = UIBarButtonItem()
-        button.title = "완료"
-        button.isEnabled = false
-        
-        return button
-    }()
+    private let viewModel: ViewModel
     
     private lazy var profileImageView: ProfileImageView = {
         let imageView = ProfileImageView()
@@ -39,52 +27,52 @@ final class SignUpViewController: UIViewController {
         
         return textField
     }()
-
+    
+    init(viewModel: ViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        setNavigationUI()
         configureUI()
-        configureNavigationBar()
         setLayoutConstraints()
     }
     
-    @objc
-    private func imageClicked() {
-        dump("Image Clicked")
-    }
-
 }
 
 private extension SignUpViewController {
     
     func configureUI() {
         view.backgroundColor = .systemBackground
-        view.addSubview(navigationBar)
         view.addSubview(profileImageView)
         view.addSubview(nicknameTextField)
     }
     
-    func configureNavigationBar() {
-        let appearance = UINavigationBarAppearance()
-        appearance.backgroundColor = .systemBackground
+    func setNavigationUI() {
         navigationItem.title = "프로필 설정"
-        navigationBar.standardAppearance = appearance
-        navigationBar.pushItem(navigationItem, animated: false)
-        navigationBar.topItem?.rightBarButtonItem = doneButton
+        navigationItem.backButtonDisplayMode = .minimal
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            title: "완료",
+            style: .done,
+            target: self,
+            action: #selector(completeButtonTapped)
+        )
     }
     
     func setLayoutConstraints() {
-        NSLayoutConstraint.activate([
-            navigationBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            navigationBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            navigationBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
-        ])
         
         NSLayoutConstraint.activate([
             profileImageView.widthAnchor.constraint(equalToConstant: 100),
             profileImageView.heightAnchor.constraint(equalToConstant: 100),
             profileImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            profileImageView.topAnchor.constraint(equalTo: navigationBar.bottomAnchor, constant: 20)
+            profileImageView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20)
         ])
         
         NSLayoutConstraint.activate([
@@ -92,6 +80,19 @@ private extension SignUpViewController {
             nicknameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             nicknameTextField.topAnchor.constraint(equalTo: profileImageView.bottomAnchor, constant: 20)
         ])
+    }
+    
+}
+
+@objc
+private extension SignUpViewController {
+    
+    func completeButtonTapped() {
+        dump("Complete Button Tapped")
+    }
+    
+    func imageClicked() {
+        dump("Image Clicked")
     }
     
 }

--- a/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import PhotosUI
 
 final class SignUpViewController: UIViewController {
     
@@ -85,14 +86,36 @@ private extension SignUpViewController {
 }
 
 @objc
-private extension SignUpViewController {
+extension SignUpViewController {
     
     func completeButtonTapped() {
         dump("Complete Button Tapped")
     }
     
     func imageClicked() {
-        dump("Image Clicked")
+        let photoLibrary = PHPhotoLibrary.shared()
+        var configuration = PHPickerConfiguration(photoLibrary: photoLibrary)
+        
+        configuration.selectionLimit = 1
+        configuration.filter = .any(of: [.images])
+        DispatchQueue.main.async {
+            let picker = PHPickerViewController(configuration: configuration)
+            picker.delegate = self
+            picker.isEditing = true
+            self.present(picker, animated: true, completion: nil)
+        }
+        
+    }
+}
+extension SignUpViewController: PHPickerViewControllerDelegate {
+
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true, completion: nil)
+        guard let result = results.first else { return }
+        result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] (image, _) in
+            guard let image = image as? UIImage else { return }
+            self?.profileImageView.setProfile(image: image)
+        }
     }
     
 }

--- a/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
@@ -20,6 +20,8 @@ final class SignUpViewController: UIViewController {
     private let completeButtonSubject = PassthroughSubject<Void, Never>()
     private var cancellableBag = Set<AnyCancellable>()
     
+    let updateSuccessSubject = PassthroughSubject<Void, Never>()
+    
     private lazy var profileImageView: ProfileImageView = {
         let imageView = ProfileImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -117,6 +119,7 @@ private extension SignUpViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
                 self?.navigationController?.popViewController(animated: true)
+                self?.updateSuccessSubject.send()
             }
             .store(in: &cancellableBag)
         

--- a/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
@@ -116,8 +116,7 @@ private extension SignUpViewController {
         output.completeButtonOutput
             .receive(on: DispatchQueue.main)
             .sink { [weak self] in
-                self?.dismiss(animated: true)
-                // TODO: 마이페이지 새로고침
+                self?.navigationController?.popViewController(animated: true)
             }
             .store(in: &cancellableBag)
         

--- a/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
+++ b/iOS/Village/Village/Presentation/SignUp/View/SignUpViewController.swift
@@ -34,6 +34,18 @@ final class SignUpViewController: UIViewController {
         return textField
     }()
     
+    private lazy var completeButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(
+            title: "완료",
+            style: .done,
+            target: self,
+            action: #selector(completeButtonTapped)
+        )
+        button.isEnabled = false
+        
+        return button
+    }()
+    
     init(viewModel: ViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
@@ -67,12 +79,7 @@ private extension SignUpViewController {
     func setNavigationUI() {
         navigationItem.title = "프로필 설정"
         navigationItem.backButtonDisplayMode = .minimal
-        navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "완료",
-            style: .done,
-            target: self,
-            action: #selector(completeButtonTapped)
-        )
+        navigationItem.rightBarButtonItem = completeButton
     }
     
     func setLayoutConstraints() {
@@ -96,6 +103,13 @@ private extension SignUpViewController {
             nicknameInput: nicknameSubject,
             profileImageDataInput: profileImageDataSubject
         ))
+        
+        output.completeButtonOutput
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isEnable in
+                self?.completeButton.isEnabled = isEnable
+            }
+            .store(in: &cancellableBag)
         
     }
     

--- a/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
+++ b/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
@@ -1,0 +1,12 @@
+//
+//  SignUpViewModel.swift
+//  Village
+//
+//  Created by 조성민 on 12/7/23.
+//
+
+import Foundation
+
+final class SignUpViewModel {
+    
+}

--- a/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
+++ b/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
@@ -26,7 +26,10 @@ final class SignUpViewModel {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] nickname in
                 self?.nowInfo.nickname = nickname
-                self?.completeButtonEnableOutput.send(self?.nowInfo != self?.previousInfo)
+                self?.completeButtonEnableOutput.send(
+                    self?.nowInfo != self?.previousInfo &&
+                    !nickname.isEmpty
+                )
             }
             .store(in: &cancellableBag)
         

--- a/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
+++ b/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
@@ -28,7 +28,7 @@ final class SignUpViewModel {
                 self?.nowInfo.nickname = nickname
                 self?.completeButtonEnableOutput.send(
                     self?.nowInfo != self?.previousInfo &&
-                    !nickname.isEmpty
+                    !nickname.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 )
             }
             .store(in: &cancellableBag)

--- a/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
+++ b/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
@@ -56,7 +56,30 @@ final class SignUpViewModel {
     }
     
     func updateProfile() {
-        // TODO: completeButtonOutput.send()
+        var nickname: String?
+        var image: Data?
+        if nowInfo.nickname != previousInfo.nickname {
+            nickname = nowInfo.nickname
+        }
+        if nowInfo.profileImage != previousInfo.profileImage {
+            image = nowInfo.profileImage
+        }
+        guard let userID = JWTManager.shared.currentUserID else { return }
+        let endpoint = APIEndPoints.patchUser(
+            userInfo: PatchUserDTO(
+                userInfo: PatchUserInfo(nickname: nickname),
+                image: image,
+                userID: userID
+            )
+        )
+        Task {
+            do {
+                try await APIProvider.shared.request(with: endpoint)
+                completeButtonOutput.send()
+            } catch {
+                dump(error)
+            }
+        }
     }
     
 }

--- a/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
+++ b/iOS/Village/Village/Presentation/SignUp/ViewModel/SignUpViewModel.swift
@@ -6,7 +6,35 @@
 //
 
 import Foundation
+import Combine
 
 final class SignUpViewModel {
+    
+    var profileInfoSubject: CurrentValueSubject<ProfileInfo, Never>
+    private let previousInfo: ProfileInfo
+    init(profileInfo: ProfileInfo) {
+        self.profileInfoSubject = CurrentValueSubject<ProfileInfo, Never>(profileInfo)
+        previousInfo = profileInfo
+    }
+    
+    func transform(input: Input) -> Output {
+        profileInfoSubject.send(profileInfoSubject.value)
+        
+        return Output(
+            profileInfoOutput: profileInfoSubject.eraseToAnyPublisher()
+        )
+    }
+    
+}
+
+extension SignUpViewModel {
+    
+    struct Input {
+        
+    }
+    
+    struct Output {
+        let profileInfoOutput: AnyPublisher<ProfileInfo, Never>
+    }
     
 }

--- a/iOS/Village/Village/Presentation/Utils/Extensions/UIImage+Resize.swift
+++ b/iOS/Village/Village/Presentation/Utils/Extensions/UIImage+Resize.swift
@@ -5,4 +5,31 @@
 //  Created by 조성민 on 12/8/23.
 //
 
-import Foundation
+import UIKit
+
+extension UIImage {
+    
+    func resize(newWidth: CGFloat, newHeight: CGFloat) -> UIImage {
+        let size = CGSize(width: newWidth, height: newHeight)
+        let render = UIGraphicsImageRenderer(size: size)
+        let renderImage = render.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: size))
+        }
+        
+        return renderImage
+    }
+    
+    func resizeKeepScale(newWidth: CGFloat) -> UIImage {
+        let scale = newWidth / self.size.width
+        let newHeight = self.size.height * scale
+        
+        let size = CGSize(width: newWidth, height: newHeight)
+        let render = UIGraphicsImageRenderer(size: size)
+        let renderImage = render.image { _ in
+            self.draw(in: CGRect(origin: .zero, size: size))
+        }
+        
+        return renderImage
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/Utils/Extensions/UIImage+Resize.swift
+++ b/iOS/Village/Village/Presentation/Utils/Extensions/UIImage+Resize.swift
@@ -1,0 +1,8 @@
+//
+//  UIImage+Resize.swift
+//  Village
+//
+//  Created by 조성민 on 12/8/23.
+//
+
+import Foundation


### PR DESCRIPTION
## 이슈
- #384 

## 체크리스트
- 프로필 사진을 설정할 수 있다.
- 자신의 닉네임을 변경할 수 있다.
- 변경된 사항이 없다면 완료 버튼을 비활성화한다.
- 변경후 마이페이지를 새로고침한다.

## 고민한 내용
- 사진을 선택하는 것이 권한이 꼭 필요한 줄 알았지만 PHPicker를 사용하면 권한이 필요없다는 것을 알게 됐습니다.
- View를 업데이트 할 때는 항상 DispatchQueue.main 에서 진행해야 합니다. 
- 이미지의 용량을 줄이기 위해서 원래 이미지에서 우리에게 꼭 필요한 크기로 사이즈를 줄이는 것을 구현했습니다.

## 스크린샷
![Simulator Screen Recording - iPhone 15 Pro - 2023-12-09 at 02 21 37](https://github.com/boostcampwm2023/iOS05-Village/assets/128480641/458a7845-ef99-4020-81c1-3b87359472e5)
