### PR TITLE
[BE/#412] 푸시 알림에서 전송자 이름으로 변경

### DIFF
--- a/BE/src/chat/chat.service.ts
+++ b/BE/src/chat/chat.service.ts
@@ -181,8 +181,12 @@ export class ChatService {
       chatRoom.writerUser.user_hash === message.sender
         ? chatRoom.userUser
         : chatRoom.writerUser;
+    const sender: UserEntity =
+      chatRoom.writerUser.user_hash !== message.sender
+        ? chatRoom.userUser
+        : chatRoom.writerUser;
     const pushMessage: PushMessage = this.fcmHandler.createChatPushMessage(
-      receiver.nickname,
+      sender.nickname,
       message.message,
       message.room_id,
     );


### PR DESCRIPTION
## 이슈
- #412

## 체크리스트
- [x] 푸시 알림에서 전송자 이름으로 변경


## 고민한 내용
- 푸시 알림에 받는 사람 이름이 떠서 변경하였다.

## 스크린샷
