### PR TITLE
[iOS/#388] 채팅방 프로필 사진 적용

### DIFF
--- a/iOS/Village/Village/Domain/Network/GetRoomResponseDTO.swift
+++ b/iOS/Village/Village/Domain/Network/GetRoomResponseDTO.swift
@@ -33,10 +33,18 @@ struct Chat: Hashable, Codable {
 
 struct GetRoomResponseDTO: Codable {
     
+    let writer: String
+    let writerProfileIMG: String
+    let user: String
+    let userProfileIMG: String
     let postID: Int
     let chatLog: [Chat]
     
     enum CodingKeys: String, CodingKey {
+        case writer
+        case writerProfileIMG = "writer_profile_img"
+        case user
+        case userProfileIMG = "user_profile_img"
         case postID = "post_id"
         case chatLog = "chat_log"
     }

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomTableViewCell.swift
@@ -44,15 +44,16 @@ final class ChatRoomTableViewCell: UITableViewCell {
         profileImageView.isHidden = true
     }
     
-    func configureData(message: String, profileImageURL: String) {
+    func configureData(message: String) {
         messageView.text = message
         messageView.sizeToFit()
+    }
+    
+    func configureImage(imageURL: String) {
         Task {
             do {
-                let data = try await APIProvider.shared.request(from: profileImageURL)
-                
+                let data = try await APIProvider.shared.request(from: imageURL)
                 profileImageView.image = UIImage(data: data)
-                
             } catch let error {
                 dump(error)
             }

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomTableViewCell.swift
@@ -40,8 +40,8 @@ final class ChatRoomTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func hideProfile() {
-        profileImageView.isHidden = true
+    override func prepareForReuse() {
+        profileImageView.image = nil
     }
     
     func configureData(message: String) {
@@ -49,15 +49,8 @@ final class ChatRoomTableViewCell: UITableViewCell {
         messageView.sizeToFit()
     }
     
-    func configureImage(imageURL: String) {
-        Task {
-            do {
-                let data = try await APIProvider.shared.request(from: imageURL)
-                profileImageView.image = UIImage(data: data)
-            } catch let error {
-                dump(error)
-            }
-        }
+    func configureImage(image: Data) {
+        profileImageView.image = UIImage(data: image)
     }
 
 }

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -109,7 +109,7 @@ final class ChatRoomViewController: UIViewController {
         textField.translatesAutoresizingMaskIntoConstraints = false
         textField.placeholder = "메시지를 입력해주세요."
         textField.borderStyle = .roundedRect
-        textField.backgroundColor = .grey100
+        textField.backgroundColor = .keyboardTextField
         
         return textField
     }()

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -22,8 +22,12 @@ final class ChatRoomViewController: UIViewController {
     
     private let roomID: Just<Int>
     private let opponentNickname: String
+    private var writer: String?
+    private var writerIMG: String?
+    private var user: String?
+    private var userIMG: String?
     
-    private var imageURL: String?
+//    private var imageURL: String?
     private var postID: AnyPublisher<Int, Never>?
     
     private let reuseIdentifier = ChatRoomTableViewCell.identifier
@@ -42,16 +46,17 @@ final class ChatRoomViewController: UIViewController {
         tableView: chatTableView,
         cellProvider: { [weak self] (tableView, indexPath, message) in
             guard let self = self else { return ChatRoomTableViewCell() }
+            guard let imageURL = self.writer == message.sender ? self.writerIMG : self.userIMG else {
+                return ChatRoomTableViewCell()
+            }
             if message.sender == JWTManager.shared.currentUserID {
                 guard let cell = tableView.dequeueReusableCell(
                     withIdentifier: ChatRoomTableViewCell.identifier,
                     for: indexPath) as? ChatRoomTableViewCell else {
                     return ChatRoomTableViewCell()
                 }
-                cell.configureData(
-                    message: message.message,
-                    profileImageURL: ""
-                )
+                cell.configureData(message: message.message)
+                cell.configureImage(imageURL: imageURL)
                 cell.selectionStyle = .none
                 return cell
             } else {
@@ -60,10 +65,8 @@ final class ChatRoomViewController: UIViewController {
                     for: indexPath) as? OpponentChatTableViewCell else {
                     return OpponentChatTableViewCell()
                 }
-                cell.configureData(
-                    message: message.message,
-                    profileImageURL: ""
-                )
+                cell.configureData(message: message.message)
+                cell.configureImage(imageURL: imageURL)
                 cell.selectionStyle = .none
                 return cell
             }
@@ -314,7 +317,10 @@ private extension ChatRoomViewController {
         room.chatLog.forEach { [weak self] chat in
             self?.viewModel.appendLog(sender: chat.sender, message: chat.message)
         }
-        
+        self.writer = room.writer
+        self.writerIMG = room.writerProfileIMG
+        self.user = room.user
+        self.userIMG = room.userProfileIMG
         self.postID = Just(room.postID).eraseToAnyPublisher()
         guard let postID = self.postID else { return }
         let output = viewModel.transformPost(input: ViewModel.PostInput(postID: postID))

--- a/iOS/Village/Village/Presentation/ChatRoom/View/OpponentChatTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/OpponentChatTableViewCell.swift
@@ -40,8 +40,8 @@ final class OpponentChatTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func hideProfile() {
-        profileImageView.isHidden = true
+    override func prepareForReuse() {
+        profileImageView.image = nil
     }
     
     func configureData(message: String) {
@@ -49,16 +49,8 @@ final class OpponentChatTableViewCell: UITableViewCell {
         messageView.sizeToFit()
     }
     
-    func configureImage(imageURL: String) {
-        Task {
-            do {
-                let
-                data = try await APIProvider.shared.request(from: imageURL)
-                profileImageView.image = UIImage(data: data)
-            } catch let error {
-                dump(error)
-            }
-        }
+    func configureImage(image: Data) {
+        profileImageView.image = UIImage(data: image)
     }
 
 }

--- a/iOS/Village/Village/Presentation/ChatRoom/View/OpponentChatTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/OpponentChatTableViewCell.swift
@@ -44,15 +44,17 @@ final class OpponentChatTableViewCell: UITableViewCell {
         profileImageView.isHidden = true
     }
     
-    func configureData(message: String, profileImageURL: String) {
+    func configureData(message: String) {
         messageView.text = message
         messageView.sizeToFit()
+    }
+    
+    func configureImage(imageURL: String) {
         Task {
             do {
-                let data = try await APIProvider.shared.request(from: profileImageURL)
-                
+                let
+                data = try await APIProvider.shared.request(from: imageURL)
                 profileImageView.image = UIImage(data: data)
-                
             } catch let error {
                 dump(error)
             }

--- a/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -107,9 +107,7 @@ final class ChatRoomViewModel {
     }
     
     func checkSender(message: Message) -> Bool {
-        debugPrint("\(message) \(chatLog.count)")
         if message.count >= 1 {
-            debugPrint(chatLog[message.count-1].sender != chatLog[message.count].sender)
             return chatLog[message.count-1].sender != chatLog[message.count].sender ? true : false
         }
         return true

--- a/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -26,6 +26,8 @@ final class ChatRoomViewModel {
     
     private var chatRoom = PassthroughSubject<GetRoomResponseDTO, NetworkError>()
     private var post = PassthroughSubject<PostResponseDTO, NetworkError>()
+    private var writerProfileData: Data?
+    private var userProfileData: Data?
     private var cancellableBag = Set<AnyCancellable>()
     private var chatLog: [Message] = []
     
@@ -79,6 +81,38 @@ final class ChatRoomViewModel {
     
     func getLog() -> [Message] {
         return chatLog
+    }
+    
+    func getData(writerURL: String, userURL: String) {
+        Task {
+            do {
+                let writerData = try await APIProvider.shared.request(from: writerURL)
+                let userData = try await APIProvider.shared.request(from: userURL)
+                writerProfileData = writerData
+                userProfileData = userData
+            } catch let error {
+                dump(error)
+            }
+        }
+    }
+    
+    func getUserData() -> Data {
+        guard let data = userProfileData else { return Data() }
+        return data
+    }
+    
+    func getWriterData() -> Data {
+        guard let data = writerProfileData else { return Data() }
+        return data
+    }
+    
+    func checkSender(message: Message) -> Bool {
+        debugPrint("\(message) \(chatLog.count)")
+        if message.count >= 1 {
+            debugPrint(chatLog[message.count-1].sender != chatLog[message.count].sender)
+            return chatLog[message.count-1].sender != chatLog[message.count].sender ? true : false
+        }
+        return true
     }
     
 }

--- a/iOS/Village/Village/Resources/Assets.xcassets/KeyboardTextFieldColor.colorset/Contents.json
+++ b/iOS/Village/Village/Resources/Assets.xcassets/KeyboardTextFieldColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.973",
+          "green" : "0.973",
+          "red" : "0.973"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.227",
+          "green" : "0.220",
+          "red" : "0.220"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## 이슈
- #388

## 체크리스트
- [x] 프로필 사진 가져오고 적용
- [x] 가장 위의 채팅에 대해서만 프로필 사진 적용
- [x] 키보드 텍스트 필드 다크모드 적용 

## 고민한 내용
### 사진데이터에 대해서 어떻게 가져올 지 생각
- 뷰모델에 저장해주고 필요할때마다 데이터를 꺼내오는 방식으로 적용
### 가장 위의 채팅에 대해서만 프로필 사진 적용하는 방식
- 이전의 채팅과 비교해서 다를 시에만 적용하도록 했는데 아래로 내릴때 프로필 사진이 적용되어있음.
- prepareForReuse를 적용해서 이미지를 nil로 바꿔주니 어느정도 해결됨
- 데이터를 아직 못불러왔을때는 프로필사진이 안뜸.. 해결방법 좀 알려주세요.. 고쉰ㅁ

## 스크린샷
<img src=https://github.com/boostcampwm2023/iOS05-Village/assets/59719500/10f0ead7-3606-4453-b600-8b819118184a width=300 />
<img src=https://github.com/boostcampwm2023/iOS05-Village/assets/59719500/df8d91b8-aaff-4000-98b5-d5f57f194e13 width=300 />

