### PR TITLE
[BE/#412] access token 블랙리스트 도입

### DIFF
--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -30,6 +30,7 @@ import { RedisConfigProvider } from './config/redis.config';
       useClass: MysqlConfigProvider,
     }),
     CacheModule.registerAsync({
+      isGlobal: true,
       useClass: RedisConfigProvider,
     }),
     PostsBlockModule,

--- a/BE/src/config/redis.config.ts
+++ b/BE/src/config/redis.config.ts
@@ -8,6 +8,8 @@ export class RedisConfigProvider implements CacheOptionsFactory {
       store: redisStore,
       host: this.configService.get('REDIS_HOST'),
       port: this.configService.get('REDIS_PORT'),
+      password: this.configService.get('REDIS_PASSWORD'),
+      ttl: 0,
     };
   }
 }

--- a/BE/src/config/redis.config.ts
+++ b/BE/src/config/redis.config.ts
@@ -9,7 +9,6 @@ export class RedisConfigProvider implements CacheOptionsFactory {
       host: this.configService.get('REDIS_HOST'),
       port: this.configService.get('REDIS_PORT'),
       password: this.configService.get('REDIS_PASSWORD'),
-      ttl: 0,
     };
   }
 }

--- a/BE/src/login/login.controller.ts
+++ b/BE/src/login/login.controller.ts
@@ -46,8 +46,9 @@ export class LoginController {
   checkAccessToken() {}
 
   @Post('logout')
-  logout(@Headers('Authorization') token, @UserHash() userId) {
+  @UseGuards(AuthGuard)
+  async logout(@Headers('Authorization') token) {
     const accessToken = token.split(' ')[1];
-    this.loginService.logout(userId, accessToken);
+    await this.loginService.logout(accessToken);
   }
 }

--- a/BE/src/utils/auth.guard.ts
+++ b/BE/src/utils/auth.guard.ts
@@ -2,24 +2,32 @@ import {
   CanActivate,
   ExecutionContext,
   HttpException,
+  Inject,
   Injectable,
 } from '@nestjs/common';
 import * as jwt from 'jsonwebtoken';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
-  canActivate(context: ExecutionContext): boolean {
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+  async canActivate(context: ExecutionContext): Promise<boolean> {
     const authorizationHeader = context.switchToHttp().getRequest()
       .headers.authorization;
 
     if (!authorizationHeader) throw new HttpException('토큰이 없습니다.', 401);
-    else {
-      try {
-        jwt.verify(authorizationHeader.split(' ')[1], process.env.JWT_SECRET);
-        return true;
-      } catch (err) {
-        return false;
-      }
+
+    const accessToken = authorizationHeader.split(' ')[1];
+    const isBlackList = await this.cacheManager.get(accessToken);
+    if (isBlackList) {
+      throw new HttpException('로그아웃된 토큰입니다.', 401);
+    }
+    try {
+      jwt.verify(accessToken, process.env.JWT_SECRET);
+      return true;
+    } catch (err) {
+      return false;
     }
   }
 }


### PR DESCRIPTION
## 이슈
- #412

## 체크리스트
- [x] 로그아웃 시 블랙리스트에 등록

## 고민한 내용
- 로그아웃시 해당 엑세스 토큰을 블랙리스트에 적용함
- 로그아웃시 registration token 삭제도 같이 일어나기 때문에 가드를 적용해서 유효한 엑세스 토큰을 가진 요청만 삭제되도록 수정
   - 가드가 없으면 만료된 jwt로 악의적으로 사용자의 registration token을 삭제 할 수 있기 때문

## 스크린샷
