### PR TITLE
[iOS/#69] 대여 게시글 등록 화면 사진 등록 로직 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -31,6 +31,10 @@
 		446362CB2B0DFD4F00B74DA7 /* Int+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446362CA2B0DFD4F00B74DA7 /* Int+.swift */; };
 		446362CF2B0F042500B74DA7 /* PostInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446362CE2B0F042500B74DA7 /* PostInfoView.swift */; };
 		446362D12B0F050600B74DA7 /* UserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446362D02B0F050600B74DA7 /* UserInfoView.swift */; };
+		446B60F72B220D6000A361CB /* CameraButtonCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B60F62B220D6000A361CB /* CameraButtonCell.swift */; };
+		446B60F92B220D9500A361CB /* ImageViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B60F82B220D9500A361CB /* ImageViewCell.swift */; };
+		446B60FB2B220DC400A361CB /* ImageUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B60FA2B220DC400A361CB /* ImageUploadView.swift */; };
+		446B61002B2433E100A361CB /* ImageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B60FF2B2433E100A361CB /* ImageItem.swift */; };
 		4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491AA272B05D6C90016FC70 /* MenuView.swift */; };
 		44C1F5E32B0FB6460047A436 /* PostListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C1F5E22B0FB6460047A436 /* PostListItem.swift */; };
 		44C1F5E62B0FE37C0047A436 /* PostDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C1F5E52B0FE37C0047A436 /* PostDetailViewModel.swift */; };
@@ -152,6 +156,10 @@
 		446362CA2B0DFD4F00B74DA7 /* Int+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+.swift"; sourceTree = "<group>"; };
 		446362CE2B0F042500B74DA7 /* PostInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostInfoView.swift; sourceTree = "<group>"; };
 		446362D02B0F050600B74DA7 /* UserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoView.swift; sourceTree = "<group>"; };
+		446B60F62B220D6000A361CB /* CameraButtonCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraButtonCell.swift; sourceTree = "<group>"; };
+		446B60F82B220D9500A361CB /* ImageViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewCell.swift; sourceTree = "<group>"; };
+		446B60FA2B220DC400A361CB /* ImageUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadView.swift; sourceTree = "<group>"; };
+		446B60FF2B2433E100A361CB /* ImageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageItem.swift; sourceTree = "<group>"; };
 		4491AA272B05D6C90016FC70 /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
 		44C1F5E22B0FB6460047A436 /* PostListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListItem.swift; sourceTree = "<group>"; };
 		44C1F5E52B0FE37C0047A436 /* PostDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailViewModel.swift; sourceTree = "<group>"; };
@@ -372,6 +380,23 @@
 			path = Custom;
 			sourceTree = "<group>";
 		};
+		446B60F52B220D4300A361CB /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				446B60F62B220D6000A361CB /* CameraButtonCell.swift */,
+				446B60F82B220D9500A361CB /* ImageViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		446B60FE2B24330100A361CB /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				446B60FF2B2433E100A361CB /* ImageItem.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		44C1F5E12B0FB6380047A436 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -481,11 +506,13 @@
 		59BD5DD22B0C7A0A00FEB80F /* Custom */ = {
 			isa = PBXGroup;
 			children = (
+				446B60F52B220D4300A361CB /* Cell */,
 				59AABDDE2B0E1AE1002F6D0E /* PostCreateTitleView.swift */,
 				59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */,
 				59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */,
 				59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */,
 				59D4DBDD2B06889300BBA2D5 /* TimePickerView.swift */,
+				446B60FA2B220DC400A361CB /* ImageUploadView.swift */,
 			);
 			path = Custom;
 			sourceTree = "<group>";
@@ -530,6 +557,7 @@
 		59E196C72B045EFA00BF7C5A /* PostCreate */ = {
 			isa = PBXGroup;
 			children = (
+				446B60FE2B24330100A361CB /* Model */,
 				59BD5DD12B0C786600FEB80F /* ViewModel */,
 				59BD5DD02B0C785900FEB80F /* View */,
 			);
@@ -1017,10 +1045,12 @@
 				59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */,
 				8F1E2CEE2B1F163D00179E34 /* GetRoomResponseDTO.swift in Sources */,
 				59E6A20F2B205C8500A2DF21 /* RequestPostSummaryView.swift in Sources */,
+				446B61002B2433E100A361CB /* ImageItem.swift in Sources */,
 				8F8F0B932B1DC0C300BE97D2 /* PostRoomRequestDTO.swift in Sources */,
 				59E6A2072B1F374B00A2DF21 /* MyPostsViewModel.swift in Sources */,
 				59BA10FA2B1CC3F700F30DB8 /* FCMManager.swift in Sources */,
 				8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */,
+				446B60F72B220D6000A361CB /* CameraButtonCell.swift in Sources */,
 				8F1B53382B0E03AE006D8982 /* PostListResponseDTO.swift in Sources */,
 				4416D48C2B174C7A0052BF33 /* KeychainManager.swift in Sources */,
 				59457BC72B233EE5003F798C /* UIImage+Resize.swift in Sources */,
@@ -1060,6 +1090,7 @@
 				59E6A2042B1F325E00A2DF21 /* MyPostsViewController.swift in Sources */,
 				4416D47E2B171BF30052BF33 /* LoginViewModel.swift in Sources */,
 				8F95CF942B0C60E00024631F /* HTTPMethod.swift in Sources */,
+				446B60FB2B220DC400A361CB /* ImageUploadView.swift in Sources */,
 				445D62B02B1DD6EC005DD3B1 /* AuthInterceptor.swift in Sources */,
 				8F3D79E22B14438A00370536 /* PostView.swift in Sources */,
 				59E0C5FC2AFBA3FC0073D494 /* AppDelegate.swift in Sources */,
@@ -1087,6 +1118,7 @@
 				8FD52A482B09D1AD005EE367 /* MyPageViewController.swift in Sources */,
 				8F3D79E02B136C6800370536 /* ChatRoomViewModel.swift in Sources */,
 				44C1F5ED2B0FE44A0047A436 /* UserResponseDTO.swift in Sources */,
+				446B60F92B220D9500A361CB /* ImageViewCell.swift in Sources */,
 				8FD52A4B2B0B0A2F005EE367 /* SearchViewController.swift in Sources */,
 				8F95CF962B0C66910024631F /* Requestable.swift in Sources */,
 				59D8F1052B103A7200A08E02 /* PostModifyRequestDTO.swift in Sources */,

--- a/iOS/Village/Village/Common/Constants.swift
+++ b/iOS/Village/Village/Common/Constants.swift
@@ -25,6 +25,7 @@ enum ImageSystemName: String {
     case paperplane
     case checkmark
     case cameraCircleFill = "camera.circle.fill"
+    case cameraFill = "camera.fill"
     
 }
 

--- a/iOS/Village/Village/Common/Constants.swift
+++ b/iOS/Village/Village/Common/Constants.swift
@@ -27,3 +27,9 @@ enum ImageSystemName: String {
     case cameraCircleFill = "camera.circle.fill"
     
 }
+
+enum Constant {
+    
+    static let maxImageCount = 12
+    
+}

--- a/iOS/Village/Village/Domain/Network/PostModifyRequestDTO.swift
+++ b/iOS/Village/Village/Domain/Network/PostModifyRequestDTO.swift
@@ -32,7 +32,7 @@ struct PostModifyRequestDTO: Encodable, MultipartFormData {
         
         image.forEach { image in
             body.appendString("--\(boundary)\r\n")
-            body.appendString("Content-Disposition: form-data; name=\"image\";\r\n")
+            body.appendString("Content-Disposition: form-data; name=\"image\"; filename=\"image.png\"\r\n")
             body.appendString("Content-Type: image\r\n\r\n")
             body.append(image)
             body.appendString("\r\n")

--- a/iOS/Village/Village/Presentation/PostCreate/Model/ImageItem.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/Model/ImageItem.swift
@@ -1,0 +1,19 @@
+//
+//  ImageItem.swift
+//  Village
+//
+//  Created by 정상윤 on 12/9/23.
+//
+
+import Foundation
+
+struct ImageItem: Hashable {
+    
+    let id = UUID()
+    let data: Data
+    
+    init(data: Data) {
+        self.data = data
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/CameraButtonCell.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/CameraButtonCell.swift
@@ -12,7 +12,7 @@ final class CameraButtonCell: UICollectionViewCell {
     private lazy var cameraButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
         configuration.imagePlacement = .top
-        configuration.image = UIImage(systemName: "camera.fill")
+        configuration.image = UIImage(systemName: ImageSystemName.cameraFill.rawValue)
         configuration.baseForegroundColor = .grey100
         configuration.imagePadding = 5
         

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/CameraButtonCell.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/CameraButtonCell.swift
@@ -1,0 +1,62 @@
+//
+//  CameraButtonCell.swift
+//  Village
+//
+//  Created by 정상윤 on 12/7/23.
+//
+
+import UIKit
+
+final class CameraButtonCell: UICollectionViewCell {
+    
+    private lazy var cameraButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.imagePlacement = .top
+        configuration.image = UIImage(systemName: "camera.fill")
+        configuration.baseForegroundColor = .grey100
+        configuration.imagePadding = 5
+        
+        let button = UIButton(configuration: configuration)
+        button.setLayer(cornerRadius: 5)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        addSubview(cameraButton)
+        setLayoutConstraint()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setImageCount(_ count: Int) {
+        let attributedTitle = NSAttributedString(
+            string: "\(count)/\(Constant.maxImageCount)",
+            attributes: [.font: UIFont.systemFont(ofSize: 14, weight: .light)]
+        )
+        cameraButton.setAttributedTitle(attributedTitle, for: .normal)
+    }
+    
+    func addButtonAction(_ action: UIAction) {
+        cameraButton.addAction(action, for: .touchUpInside)
+    }
+    
+}
+
+private extension CameraButtonCell {
+    
+    func setLayoutConstraint() {
+        NSLayoutConstraint.activate([
+            cameraButton.leadingAnchor.constraint(equalTo: leadingAnchor),
+            cameraButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+            cameraButton.topAnchor.constraint(equalTo: topAnchor),
+            cameraButton.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/ImageViewCell.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/ImageViewCell.swift
@@ -1,0 +1,57 @@
+//
+//  ImageViewCell.swift
+//  Village
+//
+//  Created by 정상윤 on 12/7/23.
+//
+
+import UIKit
+import Combine
+
+final class ImageViewCell: UICollectionViewCell {
+    
+    private lazy var imageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFill
+        view.layer.cornerRadius = 5
+        
+        return view
+    }()
+    
+    private override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        clipsToBounds = true
+        addSubview(imageView)
+        setLayoutConstraint()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        imageView.image = nil
+    }
+    
+    func setImage(data: Data) {
+        imageView.image = UIImage(data: data)
+    }
+    
+}
+
+private extension ImageViewCell {
+    
+    func setLayoutConstraint() {
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/ImageUploadView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/ImageUploadView.swift
@@ -1,0 +1,132 @@
+//
+//  ImageUploadView.swift
+//  Village
+//
+//  Created by 정상윤 on 12/7/23.
+//
+
+import UIKit
+
+final class ImageUploadView: UIView {
+
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, Item>
+    
+    private let imageViewCellReuseIdentifier = ImageViewCell.identifier
+    private let cameraButtonCellReuseIdentifier = CameraButtonCell.identifier
+    private let cellSize = CGSize(width: 60, height: 60)
+    private var cameraButtonAction: UIAction
+    
+    private lazy var collectionViewLayout: UICollectionViewFlowLayout = {
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.itemSize = cellSize
+        layout.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
+        
+        return layout
+    }()
+    
+    private lazy var collectionView: UICollectionView = {
+        let view = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.showsHorizontalScrollIndicator = false
+        view.isScrollEnabled = true
+        view.clipsToBounds = true
+        view.contentInset = .zero
+        view.register(ImageViewCell.self,
+                      forCellWithReuseIdentifier: imageViewCellReuseIdentifier)
+        view.register(CameraButtonCell.self,
+                      forCellWithReuseIdentifier: cameraButtonCellReuseIdentifier)
+        
+        return view
+    }()
+    
+    private lazy var dataSource = DataSource(
+        collectionView: collectionView,
+        cellProvider: { [weak self] (collectionView, indexPath, item) -> UICollectionViewCell in
+            guard let self = self else { return UICollectionViewCell() }
+            switch item {
+            case .cameraButton(let count):
+                guard let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: self.cameraButtonCellReuseIdentifier, for: indexPath)
+                        as? CameraButtonCell else { return UICollectionViewCell() }
+                
+                cell.addButtonAction(cameraButtonAction)
+                cell.setImageCount(count)
+                return cell
+                
+            case .imageItem(let imageItem):
+                guard let cell = collectionView.dequeueReusableCell(
+                    withReuseIdentifier: self.imageViewCellReuseIdentifier, for: indexPath)
+                        as? ImageViewCell else { return UICollectionViewCell() }
+                
+                cell.setImage(data: imageItem.data)
+                
+                return cell
+            }
+    })
+    
+    init(frame: CGRect, action: UIAction) {
+        self.cameraButtonAction = action
+        
+        super.init(frame: frame)
+        
+        addSubview(collectionView)
+        setDataSource()
+        setLayoutConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setCollectionViewDelegate(delegate: UICollectionViewDelegate) {
+        collectionView.delegate = delegate
+    }
+    
+    func setImageItem(items: [ImageItem], currentCount: Int) {
+        appendImages(items, currentCount)
+    }
+
+}
+
+extension ImageUploadView {
+    
+    enum Section {
+        case button
+        case image
+    }
+    
+    enum Item: Hashable {
+        case cameraButton(Int)
+        case imageItem(ImageItem)
+    }
+    
+    private func setDataSource() {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+        snapshot.appendSections([.button, .image])
+        snapshot.appendItems([.cameraButton(0)], toSection: .button)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+    
+    private func appendImages(_ items: [ImageItem], _ currentCount: Int) {
+        var snapshot = dataSource.snapshot()
+        snapshot.deleteItems(snapshot.itemIdentifiers(inSection: .button))
+        snapshot.appendItems([.cameraButton(currentCount)], toSection: .button)
+        snapshot.appendItems(items.map { .imageItem($0) }, toSection: .image)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+    
+}
+
+private extension ImageUploadView {
+    
+    func setLayoutConstraints() {
+        NSLayoutConstraint.activate([
+            collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            collectionView.topAnchor.constraint(equalTo: topAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+}


### PR DESCRIPTION
## 이슈
- #69 

## 체크리스트
- [x] 사진 등록 커스텀 뷰 구현
- [x] PHPickerViewControllerDelegate 구현

## 고민한 내용
- PHPicker를 띄워주는 버튼을 가진 셀과 이미지를 표시하는 셀을 한 컬렉션뷰에서 사용하도록 했습니다.
- 카메라 버튼 셀의 버튼 동작은 뷰 컨트롤러로부터 넘겨받도록 구현했습니다.
- 선택된 사진 삭제는 따로 이슈를 파서 구현하겠습니다.
- 편집 화면에서 등록된 사진도 편집할 수 있도록 추가로 구현이 필요합니다.

## 스크린샷
https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/bb4e7cbe-2b70-4a6b-872f-387c98a60f38