### PR TITLE
[BE/#422] 제목 자동완성 API 구현

### DIFF
--- a/BE/src/post/post.controller.ts
+++ b/BE/src/post/post.controller.ts
@@ -4,9 +4,7 @@ import {
   Get,
   HttpCode,
   HttpException,
-  MaxFileSizeValidator,
   Param,
-  ParseFilePipe,
   Patch,
   Post,
   Query,
@@ -36,6 +34,11 @@ export class PostController {
   async postsList(@Query() query: PostListDto, @UserHash() userId: string) {
     const posts = await this.postService.findPosts(query, userId);
     return posts;
+  }
+
+  @Get('/titles')
+  async postsTitlesList(@Query('searchKeyword') searchKeyword) {
+    return await this.postService.findPostsTitles(searchKeyword);
   }
 
   @Post()

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -261,6 +261,5 @@ export class PostService {
     return {
       titles: titles.slice(0, 5),
     };
-    // return titles.slice(0, 5);
   }
 }

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -249,4 +249,18 @@ export class PostService {
     await this.blockPostRepository.softDelete({ blocked_post: postId });
     await this.postRepository.softDelete({ id: postId });
   }
+
+  async findPostsTitles(searchKeyword: string) {
+    const posts: PostEntity[] = await this.postRepository.find({
+      where: { title: Like(`%${searchKeyword}%`) },
+      order: {
+        create_date: 'desc',
+      },
+    });
+    const titles: string[] = posts.map((post) => post.title);
+    return {
+      titles: titles.slice(0, 5),
+    };
+    // return titles.slice(0, 5);
+  }
 }

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -223,7 +223,6 @@ export class PostService {
     post.end_date = createPostDto.end_date;
     post.user_hash = userHash;
     post.thumbnail = imageLocations.length > 0 ? imageLocations[0] : null;
-    // 이미지 추가
     const res = await this.postRepository.save(post);
     if (res.is_request === false) {
       await this.createImages(imageLocations, res.id);
@@ -258,8 +257,6 @@ export class PostService {
       },
     });
     const titles: string[] = posts.map((post) => post.title);
-    return {
-      titles: titles.slice(0, 5),
-    };
+    return titles.slice(0, 5);
   }
 }


### PR DESCRIPTION
## 이슈
- #420

## 체크리스트
- [x] 키워드와 관련된 제목 찾아서 리턴

## 고민한 내용
- 쿼리파람으로 들어온 키워드를 가지고 Like() 쿼리를 보내서 제목을 가져오고 그중 최신순으로 5개를 골라서 반환하도록 구현

## 스크린샷
