### PR TITLE
[iOS/#421] 대여 게시글 등록 화면 선택 사진 삭제 구현

### DIFF
--- a/iOS/Village/Village/Common/Constants.swift
+++ b/iOS/Village/Village/Common/Constants.swift
@@ -26,6 +26,7 @@ enum ImageSystemName: String {
     case checkmark
     case cameraCircleFill = "camera.circle.fill"
     case cameraFill = "camera.fill"
+    case xCircleFill = "x.circle.fill"
     
 }
 

--- a/iOS/Village/Village/Common/Constants.swift
+++ b/iOS/Village/Village/Common/Constants.swift
@@ -26,7 +26,6 @@ enum ImageSystemName: String {
     case checkmark
     case cameraCircleFill = "camera.circle.fill"
     case cameraFill = "camera.fill"
-    case xCircleFill = "x.circle.fill"
     
 }
 

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/CameraButtonCell.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/CameraButtonCell.swift
@@ -13,7 +13,7 @@ final class CameraButtonCell: UICollectionViewCell {
         var configuration = UIButton.Configuration.plain()
         configuration.imagePlacement = .top
         configuration.image = UIImage(systemName: ImageSystemName.cameraFill.rawValue)
-        configuration.baseForegroundColor = .grey100
+        configuration.baseForegroundColor = .grey800
         configuration.imagePadding = 5
         
         let button = UIButton(configuration: configuration)

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/ImageViewCell.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/ImageViewCell.swift
@@ -15,15 +15,30 @@ final class ImageViewCell: UICollectionViewCell {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFill
         view.layer.cornerRadius = 5
+        view.clipsToBounds = true
         
         return view
+    }()
+    
+    private lazy var deleteButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: ImageSystemName.xmark.rawValue)?.resize(newWidth: 15, newHeight: 13)
+        configuration.baseForegroundColor = .black
+        
+        let button = UIButton(configuration: configuration)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.backgroundColor = .grey100
+        button.layer.cornerRadius = 10
+        
+        return button
     }()
     
     private override init(frame: CGRect) {
         super.init(frame: frame)
         
-        clipsToBounds = true
+        clipsToBounds = false
         addSubview(imageView)
+        addSubview(deleteButton)
         setLayoutConstraint()
     }
     
@@ -51,6 +66,13 @@ private extension ImageViewCell {
             imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
             imageView.topAnchor.constraint(equalTo: topAnchor),
             imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            deleteButton.widthAnchor.constraint(equalToConstant: 20),
+            deleteButton.heightAnchor.constraint(equalTo: deleteButton.widthAnchor),
+            deleteButton.centerXAnchor.constraint(equalTo: trailingAnchor, constant: -3),
+            deleteButton.centerYAnchor.constraint(equalTo: topAnchor, constant: 2)
         ])
     }
     

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/ImageViewCell.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/Cell/ImageViewCell.swift
@@ -50,10 +50,12 @@ final class ImageViewCell: UICollectionViewCell {
         super.prepareForReuse()
         
         imageView.image = nil
+        deleteButton.removeTarget(nil, action: nil, for: .touchUpInside)
     }
     
-    func setImage(data: Data) {
-        imageView.image = UIImage(data: data)
+    func configure(imageData: Data, deleteAction: UIAction) {
+        imageView.image = UIImage(data: imageData)
+        deleteButton.addAction(deleteAction, for: .touchUpInside)
     }
     
 }

--- a/iOS/Village/Village/Presentation/PostCreate/View/Custom/ImageUploadView.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/Custom/ImageUploadView.swift
@@ -30,7 +30,7 @@ final class ImageUploadView: UIView {
         view.translatesAutoresizingMaskIntoConstraints = false
         view.showsHorizontalScrollIndicator = false
         view.isScrollEnabled = true
-        view.clipsToBounds = true
+        view.clipsToBounds = false
         view.contentInset = .zero
         view.register(ImageViewCell.self,
                       forCellWithReuseIdentifier: imageViewCellReuseIdentifier)

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -173,12 +173,22 @@ final class PostCreateViewModel {
             }
             .store(in: &cancellableBag)
         
+        input.deleteImagePublisher
+            .sink { [weak self] item in
+                self?.deleteImage(item: item)
+            }
+            .store(in: &cancellableBag)
+        
         return Output(
             warningResult: warningPublisher.eraseToAnyPublisher(),
             endResult: endOutput.eraseToAnyPublisher(),
             editInitOutput: editInitPublisher.eraseToAnyPublisher(),
             imageOutput: imageOutput.eraseToAnyPublisher()
         )
+    }
+    
+    func deleteImage(item: ImageItem) {
+        images.removeAll(where: {$0.id == item.id})
     }
     
 }
@@ -190,6 +200,7 @@ extension PostCreateViewModel {
         var postInfoInput: PassthroughSubject<PostModifyInfo, Never>
         var editSetInput: PassthroughSubject<Void, Never>
         var selectedImagePublisher: AnyPublisher<[Data], Never>
+        var deleteImagePublisher: AnyPublisher<ImageItem, Never>
         
     }
     

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -37,7 +37,7 @@ final class PostCreateViewModel {
     let isRequest: Bool
     let isEdit: Bool
     let postID: Int?
-    private var images = [Data]()
+    private var images = [ImageItem]()
     var imagesCount: Int {
         images.count
     }
@@ -152,7 +152,7 @@ final class PostCreateViewModel {
                     timeSequenceWarning: timeSequenceWarn(startTimeString: post.startTime, endTimeString: post.endTime)
                 )
                 if warning.validation == true {
-                    modifyPost(post: post, images: images)
+                    modifyPost(post: post, images: images.map(\.data))
                 } else {
                     warningPublisher.send(warning)
                 }
@@ -168,7 +168,7 @@ final class PostCreateViewModel {
         input.selectedImagePublisher
             .sink { [weak self] data in
                 let imageItems = data.map { ImageItem(data: $0) }
-                self?.images += data
+                self?.images += imageItems
                 self?.imageOutput.send(imageItems)
             }
             .store(in: &cancellableBag)


### PR DESCRIPTION
## 이슈
- #421

## 체크리스트
- [x] 이미지 셀 삭제 버튼 추가
- [x] 셀 삭제 구현
- [x] ViewModel 이미지 데이터 삭제 구현

## 고민한 내용
- 처음에는 index를 통한 삭제로 구현했으나, 불안정하게 동작하면서 `index out of range`가 발생했습니다. 셀이 재사용되는 과정에서 삭제될 아이템의 index가 섞이는 문제였습니다.
그래서 `ImageItem` 모델을 통한 삭제로 다시 구현했습니다.
- 이미지는 최대 12장이므로 삭제 동작에서의 시간 복잡도는 신경쓰지 않았습니다.

## 스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-12-10 at 01 48 20](https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/8536a494-39ca-44c0-8b02-07ce9e0d1624)