### PR TITLE
[iOS/#436] 사용자 차단 구현

### DIFF
--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -219,7 +219,7 @@ struct APIEndPoints {
     static func blockUser(userID: String) -> EndPoint<Void> {
         return EndPoint(
             baseURL: baseURL,
-            path: "users/block",
+            path: "users/block/\(userID)",
             method: .POST
         )
     }

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -216,4 +216,12 @@ struct APIEndPoints {
         )
     }
     
+    static func hideUser(userID: String) -> EndPoint<Void> {
+        return EndPoint(
+            baseURL: baseURL,
+            path: "users/block",
+            method: .POST
+        )
+    }
+    
 }

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -216,7 +216,7 @@ struct APIEndPoints {
         )
     }
     
-    static func hideUser(userID: String) -> EndPoint<Void> {
+    static func blockUser(userID: String) -> EndPoint<Void> {
         return EndPoint(
             baseURL: baseURL,
             path: "users/block",

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -18,6 +18,7 @@ final class PostDetailViewController: UIViewController {
     private var isRequest: Bool?
     private var deletePostID = PassthroughSubject<Int, Never>()
     private let hidePost = PassthroughSubject<Int, Never>()
+    private let blockUser = PassthroughSubject<Int, Never>()
     
     private let viewModel = ViewModel()
     private var cancellableBag = Set<AnyCancellable>()
@@ -149,8 +150,9 @@ final class PostDetailViewController: UIViewController {
     }
     
     private var banAction: UIAlertAction {
-        lazy var action = UIAlertAction(title: "사용자 차단하기", style: .default) { _ in
-            // TODO: ban user
+        lazy var action = UIAlertAction(title: "사용자 차단하기", style: .default) { [weak self] _ in
+            guard let id = self?.postID.output else { return }
+            self?.blockUser.send(id)
         }
         return action
     }

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -279,7 +279,8 @@ private extension PostDetailViewController {
         let output = viewModel.transformPost(input: Input(
             postID: postID.eraseToAnyPublisher(),
             deleteInput: deletePostID.eraseToAnyPublisher(),
-            hideInput: hidePost.eraseToAnyPublisher()
+            hideInput: hidePost.eraseToAnyPublisher(),
+            blockUserInput: blockUser.eraseToAnyPublisher()
         ))
         
         bindPostOutput(output)

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -332,7 +332,7 @@ private extension PostDetailViewController {
             })
             .store(in: &cancellableBag)
         
-        output.hideOutput
+        output.popViewControllerOutput
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { completion in
                 switch completion {

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -18,7 +18,7 @@ final class PostDetailViewController: UIViewController {
     private var isRequest: Bool?
     private var deletePostID = PassthroughSubject<Int, Never>()
     private let hidePost = PassthroughSubject<Int, Never>()
-    private let blockUser = PassthroughSubject<Int, Never>()
+    private let blockUser = PassthroughSubject<String, Never>()
     
     private let viewModel = ViewModel()
     private var cancellableBag = Set<AnyCancellable>()
@@ -151,8 +151,8 @@ final class PostDetailViewController: UIViewController {
     
     private var banAction: UIAlertAction {
         lazy var action = UIAlertAction(title: "사용자 차단하기", style: .default) { [weak self] _ in
-            guard let id = self?.postID.output else { return }
-            self?.blockUser.send(id)
+            guard let userIDSubject = self?.userID else { return }
+            self?.blockUser.send(userIDSubject.output)
         }
         return action
     }

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -58,7 +58,7 @@ final class PostDetailViewModel {
         return Output(
             post: post.eraseToAnyPublisher(),
             deleteOutput: deleteOutput.eraseToAnyPublisher(),
-            hideOutput: hideOutput.eraseToAnyPublisher()
+            popViewControllerOutput: hideOutput.eraseToAnyPublisher()
         )
     }
     
@@ -140,7 +140,7 @@ extension PostDetailViewModel {
     struct Output {
         var post: AnyPublisher<PostResponseDTO, NetworkError>
         var deleteOutput: AnyPublisher<Void, NetworkError>
-        var hideOutput: AnyPublisher<Void, NetworkError>
+        var popViewControllerOutput: AnyPublisher<Void, NetworkError>
     }
     
     struct UserInput {

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -14,7 +14,7 @@ final class PostDetailViewModel {
     private var user = PassthroughSubject<UserResponseDTO, NetworkError>()
     private var roomID = PassthroughSubject<PostRoomResponseDTO, NetworkError>()
     private let deleteOutput = PassthroughSubject<Void, NetworkError>()
-    private let hideOutput = PassthroughSubject<Void, NetworkError>()
+    private let popViewControllerOutput = PassthroughSubject<Void, NetworkError>()
     
     private var responseData: PostRoomResponseDTO?
     private var cancellableBag = Set<AnyCancellable>()
@@ -55,10 +55,16 @@ final class PostDetailViewModel {
             }
             .store(in: &cancellableBag)
         
+        input.blockUserInput
+            .sink { [weak self] userID in
+                self?.blockUser(userID: userID)
+            }
+            .store(in: &cancellableBag)
+        
         return Output(
             post: post.eraseToAnyPublisher(),
             deleteOutput: deleteOutput.eraseToAnyPublisher(),
-            popViewControllerOutput: hideOutput.eraseToAnyPublisher()
+            popViewControllerOutput: popViewControllerOutput.eraseToAnyPublisher()
         )
     }
     
@@ -118,14 +124,19 @@ final class PostDetailViewModel {
         Task {
             do {
                 try await APIProvider.shared.request(with: endpoint)
-                hideOutput.send()
+                popViewControllerOutput.send()
             } catch let error as NetworkError {
-                hideOutput.send(completion: .failure(error))
+                popViewControllerOutput.send(completion: .failure(error))
             } catch {
                 dump(error)
             }
         }
     }
+    
+    private func blockUser(userID: String) {
+        
+    }
+
     
 }
 
@@ -135,6 +146,7 @@ extension PostDetailViewModel {
         var postID: AnyPublisher<Int, Never>
         var deleteInput: AnyPublisher<Int, Never>
         let hideInput: AnyPublisher<Int, Never>
+        let blockUserInput: AnyPublisher<String, Never>
     }
     
     struct Output {

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -134,9 +134,19 @@ final class PostDetailViewModel {
     }
     
     private func blockUser(userID: String) {
+        let endpoint = APIEndPoints.blockUser(userID: userID)
         
+        Task {
+            do {
+                try await APIProvider.shared.request(with: endpoint)
+                popViewControllerOutput.send()
+            } catch let error as NetworkError {
+                popViewControllerOutput.send(completion: .failure(error))
+            } catch {
+                dump(error)
+            }
+        }
     }
-
     
 }
 


### PR DESCRIPTION
## 이슈
- #436

## 체크리스트
- [x] 게시글 상세에서 사용자를 차단할 수 있어야 한다.

## 고민한 내용
- 상세페이지의 입장에서 사용자를 차단하고 게시글을 숨기는 것의 결과가 뷰를 pop 하는 것이기 때문에 같은 output을 사용했다. 
