### PR TITLE
[iOS/#450] 홈 화면 사라지는 버그 수정

### DIFF
--- a/iOS/Village/Village/Presentation/Search/SearchViewController.swift
+++ b/iOS/Village/Village/Presentation/Search/SearchViewController.swift
@@ -16,6 +16,7 @@ final class SearchViewController: UIViewController {
         super.viewDidLoad()
         
         setNavigationBarUI()
+        definesPresentationContext = true
         
         view.backgroundColor = .systemBackground
     }


### PR DESCRIPTION
## 이슈
- #450 

## 체크리스트
- [x] SearchViewController에서 definesPresentationContext = true 추가

## 고민한 내용
- 해당 속성을 지정해주지 않아 UISearchController가 활성화되있는 동안 사용자가 다른 뷰 컨트롤러로 이동했을 때 search bar가 남아있는 문제였던 것 같습니다.

## 스크린샷
없음
