### PR TITLE
[iOS/#454] 신고 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		5975E98C2B035919007CEF13 /* Users.json in Resources */ = {isa = PBXBuildFile; fileRef = 5975E9892B035919007CEF13 /* Users.json */; };
 		5979BA7C2B08AE3C00FFF215 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5979BA7B2B08AE3C00FFF215 /* UITextField+.swift */; };
 		5980D75F2B0FB6DB00A6B370 /* PostCreateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5980D75E2B0FB6DB00A6B370 /* PostCreateRepository.swift */; };
+		59A384602B25FF6D00660B70 /* ReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A3845F2B25FF6D00660B70 /* ReportViewController.swift */; };
+		59A384642B26093600660B70 /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A384632B26093600660B70 /* ReportViewModel.swift */; };
 		59AABDDF2B0E1AE1002F6D0E /* PostCreateTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDDE2B0E1AE1002F6D0E /* PostCreateTitleView.swift */; };
 		59AABDE12B0E1BB8002F6D0E /* PostCreatePriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */; };
 		59AABDE32B0E272C002F6D0E /* PostCreateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */; };
@@ -186,6 +188,8 @@
 		5975E9892B035919007CEF13 /* Users.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Users.json; sourceTree = "<group>"; };
 		5979BA7B2B08AE3C00FFF215 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		5980D75E2B0FB6DB00A6B370 /* PostCreateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateRepository.swift; sourceTree = "<group>"; };
+		59A3845F2B25FF6D00660B70 /* ReportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewController.swift; sourceTree = "<group>"; };
+		59A384632B26093600660B70 /* ReportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewModel.swift; sourceTree = "<group>"; };
 		59AA129A2B03726C00AFC766 /* VillageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VillageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		59AABDDE2B0E1AE1002F6D0E /* PostCreateTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateTitleView.swift; sourceTree = "<group>"; };
 		59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreatePriceView.swift; sourceTree = "<group>"; };
@@ -437,6 +441,31 @@
 				59AA12952B036BFC00AFC766 /* Dummy */,
 			);
 			path = Data;
+			sourceTree = "<group>";
+		};
+		59A3845E2B25F88300660B70 /* Report */ = {
+			isa = PBXGroup;
+			children = (
+				59A384622B26092000660B70 /* View */,
+				59A384612B26091B00660B70 /* ViewModel */,
+			);
+			path = Report;
+			sourceTree = "<group>";
+		};
+		59A384612B26091B00660B70 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				59A384632B26093600660B70 /* ReportViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		59A384622B26092000660B70 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				59A3845F2B25FF6D00660B70 /* ReportViewController.swift */,
+			);
+			path = View;
 			sourceTree = "<group>";
 		};
 		59AA12952B036BFC00AFC766 /* Dummy */ = {
@@ -796,6 +825,7 @@
 		8FBE3AED2B03549300660530 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				59A3845E2B25F88300660B70 /* Report */,
 				59E6A2012B1F31FD00A2DF21 /* MyPosts */,
 				442442152B144268009D39A8 /* Login */,
 				4416D44D2B14A4260052BF33 /* SignUp */,
@@ -1127,6 +1157,7 @@
 				8F97D06C2B222EFA00A19754 /* OpponentChatTableViewCell.swift in Sources */,
 				8F8F0B8F2B1DB2EE00BE97D2 /* PostMuteResponseDTO.swift in Sources */,
 				8F95CF922B0C57460024631F /* NetworkError.swift in Sources */,
+				59A384602B25FF6D00660B70 /* ReportViewController.swift in Sources */,
 				44C1F5F32B0FF63C0047A436 /* PostResponseDTO.swift in Sources */,
 				8F1B53362B0E0396006D8982 /* PostListRequestDTO.swift in Sources */,
 				8F3D7A3A2B173B7C00370536 /* WebSocketError.swift in Sources */,
@@ -1179,6 +1210,7 @@
 				8F8F0B8D2B1DA91500BE97D2 /* HiddenRentPostTableViewCell.swift in Sources */,
 				59AADE382B22086400C3E17D /* SignUpViewModel.swift in Sources */,
 				8FBB65CC2B20587B00C6A133 /* BlockedUserTableViewCell.swift in Sources */,
+				59A384642B26093600660B70 /* ReportViewModel.swift in Sources */,
 				59E2C1642B248BF7004428F7 /* HiddenRequestPostTableViewCell.swift in Sources */,
 				446362CB2B0DFD4F00B74DA7 /* Int+.swift in Sources */,
 				5979BA7C2B08AE3C00FFF215 /* UITextField+.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		5980D75F2B0FB6DB00A6B370 /* PostCreateRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5980D75E2B0FB6DB00A6B370 /* PostCreateRepository.swift */; };
 		59A384602B25FF6D00660B70 /* ReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A3845F2B25FF6D00660B70 /* ReportViewController.swift */; };
 		59A384642B26093600660B70 /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A384632B26093600660B70 /* ReportViewModel.swift */; };
+		59A384662B260DB000660B70 /* ReportDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59A384652B260DB000660B70 /* ReportDTO.swift */; };
 		59AABDDF2B0E1AE1002F6D0E /* PostCreateTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDDE2B0E1AE1002F6D0E /* PostCreateTitleView.swift */; };
 		59AABDE12B0E1BB8002F6D0E /* PostCreatePriceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */; };
 		59AABDE32B0E272C002F6D0E /* PostCreateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */; };
@@ -190,6 +191,7 @@
 		5980D75E2B0FB6DB00A6B370 /* PostCreateRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateRepository.swift; sourceTree = "<group>"; };
 		59A3845F2B25FF6D00660B70 /* ReportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewController.swift; sourceTree = "<group>"; };
 		59A384632B26093600660B70 /* ReportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewModel.swift; sourceTree = "<group>"; };
+		59A384652B260DB000660B70 /* ReportDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportDTO.swift; sourceTree = "<group>"; };
 		59AA129A2B03726C00AFC766 /* VillageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VillageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		59AABDDE2B0E1AE1002F6D0E /* PostCreateTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateTitleView.swift; sourceTree = "<group>"; };
 		59AABDE02B0E1BB8002F6D0E /* PostCreatePriceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreatePriceView.swift; sourceTree = "<group>"; };
@@ -680,6 +682,7 @@
 				59457BC82B237615003F798C /* PatchUserDTO.swift */,
 				59E2C1652B24B6D9004428F7 /* RequestFilterDTO.swift */,
 				596AD1F32B2593E1005860B3 /* BlockedUserDTO.swift */,
+				59A384652B260DB000660B70 /* ReportDTO.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1211,6 +1214,7 @@
 				59AADE382B22086400C3E17D /* SignUpViewModel.swift in Sources */,
 				8FBB65CC2B20587B00C6A133 /* BlockedUserTableViewCell.swift in Sources */,
 				59A384642B26093600660B70 /* ReportViewModel.swift in Sources */,
+				59A384662B260DB000660B70 /* ReportDTO.swift in Sources */,
 				59E2C1642B248BF7004428F7 /* HiddenRequestPostTableViewCell.swift in Sources */,
 				446362CB2B0DFD4F00B74DA7 /* Int+.swift in Sources */,
 				5979BA7C2B08AE3C00FFF215 /* UITextField+.swift in Sources */,

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -240,4 +240,13 @@ struct APIEndPoints {
         )
     }
     
+    static func reportUser(reportInfo: ReportDTO) -> EndPoint<Void> {
+        return EndPoint(
+            baseURL: baseURL,
+            path: "report",
+            method: .POST,
+            bodyParameters: reportInfo
+        )
+    }
+    
 }

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -245,7 +245,8 @@ struct APIEndPoints {
             baseURL: baseURL,
             path: "report",
             method: .POST,
-            bodyParameters: reportInfo
+            bodyParameters: reportInfo,
+            headers: ["Content-Type": "application/json"]
         )
     }
     

--- a/iOS/Village/Village/Domain/Network/ReportDTO.swift
+++ b/iOS/Village/Village/Domain/Network/ReportDTO.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct ReportDTO {
+struct ReportDTO: Encodable {
     
     let postID: Int
     let userID: String

--- a/iOS/Village/Village/Domain/Network/ReportDTO.swift
+++ b/iOS/Village/Village/Domain/Network/ReportDTO.swift
@@ -1,0 +1,22 @@
+//
+//  ReportDTO.swift
+//  Village
+//
+//  Created by 조성민 on 12/11/23.
+//
+
+import Foundation
+
+struct ReportDTO {
+    
+    let postID: Int
+    let userID: String
+    let description: String
+    
+    enum CodingKeys: String, CodingKey {
+        case postID = "post_id"
+        case userID = "user_id"
+        case description
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -157,6 +157,14 @@ final class PostDetailViewController: UIViewController {
         return action
     }
     
+    private var reportAction: UIAlertAction {
+        lazy var action = UIAlertAction(title: "사용자 신고하기", style: .default) { [weak self] _ in
+            let nextVC = ReportViewController(viewModel: ReportViewModel())
+            self?.navigationController?.pushViewController(nextVC, animated: true)
+        }
+        return action
+    }
+    
     private let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
     
     init(postID: Int) {
@@ -192,6 +200,7 @@ final class PostDetailViewController: UIViewController {
         if postUserID != JWTManager.shared.currentUserID {
             alert.addAction(hideAction)
             alert.addAction(banAction)
+            alert.addAction(reportAction)
             alert.addAction(cancelAction)
         } else {
             alert.addAction(modifyAction)

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -150,7 +150,7 @@ final class PostDetailViewController: UIViewController {
     }
     
     private var banAction: UIAlertAction {
-        lazy var action = UIAlertAction(title: "사용자 차단하기", style: .default) { [weak self] _ in
+        lazy var action = UIAlertAction(title: "사용자 차단하기", style: .destructive) { [weak self] _ in
             guard let userIDSubject = self?.userID else { return }
             self?.blockUser.send(userIDSubject.output)
         }
@@ -158,7 +158,7 @@ final class PostDetailViewController: UIViewController {
     }
     
     private var reportAction: UIAlertAction {
-        lazy var action = UIAlertAction(title: "사용자 신고하기", style: .default) { [weak self] _ in
+        lazy var action = UIAlertAction(title: "신고하기", style: .destructive) { [weak self] _ in
             guard let userID = self?.userID?.output,
                   let postID = self?.postID.output else { return }
             let nextVC = ReportViewController(viewModel: ReportViewModel(

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -159,7 +159,11 @@ final class PostDetailViewController: UIViewController {
     
     private var reportAction: UIAlertAction {
         lazy var action = UIAlertAction(title: "사용자 신고하기", style: .default) { [weak self] _ in
-            let nextVC = ReportViewController(viewModel: ReportViewModel())
+            guard let userID = self?.userID?.output,
+                  let postID = self?.postID.output else { return }
+            let nextVC = ReportViewController(viewModel: ReportViewModel(
+                userID: userID, postID: postID
+            ))
             self?.navigationController?.pushViewController(nextVC, animated: true)
         }
         return action

--- a/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
+++ b/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
@@ -155,7 +155,7 @@ private extension ReportViewController {
     }
     
     func configureNavigation() {
-        navigationItem.title = "사용자 신고"
+        navigationItem.title = "신고 접수"
         navigationItem.backButtonDisplayMode = .minimal
     }
     

--- a/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
+++ b/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
@@ -77,7 +77,7 @@ final class ReportViewController: UIViewController {
     }()
     
     private lazy var completeAlert: UIAlertController = {
-        let alert = UIAlertController(title: "접수 완료", message: "신고가 접수되었습니다.", preferredStyle: .alert)
+        let alert = UIAlertController(title: nil, message: "신고가 접수되었습니다.", preferredStyle: .alert)
         let action = UIAlertAction(title: "완료", style: .default) { [weak self] _ in
             self?.navigationController?.popViewController(animated: true)
         }

--- a/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
+++ b/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
@@ -38,14 +38,24 @@ final class ReportViewController: UIViewController {
             right: 10
         )
         textView.font = .systemFont(ofSize: 14)
+        textView.delegate = self
         
         return textView
+    }()
+    
+    private lazy var descriptionCountLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "글자수 제한: 0/300"
+        label.font = .systemFont(ofSize: 12)
+        
+        return label
     }()
     
     private lazy var infoLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = "신고 내용이 사실과 다를 경우 이용 제재를 받을 수 있으니 주의해주세요."
+        label.text = "신고 내용이 사실과 다를 경우 이용 제재를 받을 수 있습니다."
         label.font = .systemFont(ofSize: 14)
         label.textColor = .darkGray
         
@@ -68,7 +78,7 @@ final class ReportViewController: UIViewController {
     
     private lazy var completeAlert: UIAlertController = {
         let alert = UIAlertController(title: "접수 완료", message: "신고가 접수되었습니다.", preferredStyle: .alert)
-        let action = UIAlertAction(title: "신고가 접수되었습니다.", style: .default) { [weak self] action in
+        let action = UIAlertAction(title: "완료", style: .default) { [weak self] _ in
             self?.navigationController?.popViewController(animated: true)
         }
         alert.addAction(action)
@@ -107,6 +117,7 @@ private extension ReportViewController {
         
         view.addSubview(headerLabel)
         view.addSubview(contentTextView)
+        view.addSubview(descriptionCountLabel)
         view.addSubview(infoLabel)
         view.addSubview(reportButton)
     }
@@ -125,15 +136,21 @@ private extension ReportViewController {
         ])
         
         NSLayoutConstraint.activate([
-            infoLabel.topAnchor.constraint(equalTo: contentTextView.bottomAnchor, constant: 10),
-            infoLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10)
+            descriptionCountLabel.topAnchor.constraint(equalTo: contentTextView.bottomAnchor, constant: 10),
+            descriptionCountLabel.trailingAnchor.constraint(equalTo: contentTextView.trailingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            infoLabel.topAnchor.constraint(equalTo: descriptionCountLabel.bottomAnchor, constant: 10),
+            infoLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
         
         NSLayoutConstraint.activate([
             reportButton.topAnchor.constraint(equalTo: infoLabel.bottomAnchor, constant: 10),
             reportButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
             reportButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
-            reportButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+            reportButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            reportButton.heightAnchor.constraint(equalToConstant: 44)
         ])
     }
     
@@ -154,6 +171,23 @@ private extension ReportViewController {
                 self?.present(alert, animated: true)
             }
             .store(in: &cancellableBag)
+    }
+    
+}
+
+extension ReportViewController: UITextViewDelegate {
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        let currentText = textView.text ?? ""
+        guard let stringRange = Range(range, in: currentText) else { return false }
+        let changedText = currentText.replacingCharacters(in: stringRange, with: text)
+        if changedText.count <= 300 {
+            descriptionCountLabel.text = "글자수 제한 : \(changedText.count)/300"
+            descriptionCountLabel.textColor = .label
+        } else {
+            descriptionCountLabel.textColor = .negative400
+        }
+        return changedText.count <= 300
     }
     
 }

--- a/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
+++ b/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
@@ -1,0 +1,134 @@
+//
+//  ReportViewController.swift
+//  Village
+//
+//  Created by 조성민 on 12/10/23.
+//
+
+import UIKit
+
+final class ReportViewController: UIViewController {
+    
+    typealias ViewModel = ReportViewModel
+    
+    private let viewModel: ViewModel
+    
+    private lazy var headerLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "신고 내용"
+        label.font = .systemFont(ofSize: 16)
+        
+        return label
+    }()
+    
+    private lazy var contentTextView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.setLayer()
+        textView.textContainerInset = UIEdgeInsets(
+            top: 10,
+            left: 10,
+            bottom: 10,
+            right: 10
+        )
+        textView.font = .systemFont(ofSize: 14)
+        
+        return textView
+    }()
+    
+    private lazy var infoLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "신고해주신 내용을 바탕으로 빌리지 팀에서 빠르게 조치하겠습니다."
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .darkGray
+        
+        return label
+    }()
+    
+    private lazy var reportButton: UIButton = {
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = "신고하기"
+        configuration.baseBackgroundColor = .primary500
+        configuration.titleAlignment = .center
+        configuration.cornerStyle = .medium
+        
+        let button = UIButton(configuration: configuration)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(reportButtonTapped), for: .touchUpInside)
+        
+        return button
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureUI()
+        configureConstraints()
+        configureNavigation()
+        bindViewModel()
+    }
+    
+    init(viewModel: ViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc private func reportButtonTapped() {
+        
+    }
+    
+}
+
+private extension ReportViewController {
+    
+    func configureUI() {
+        view.backgroundColor = .systemBackground
+        
+        view.addSubview(headerLabel)
+        view.addSubview(contentTextView)
+        view.addSubview(infoLabel)
+        view.addSubview(reportButton)
+    }
+    
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            headerLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
+            headerLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10)
+        ])
+        
+        NSLayoutConstraint.activate([
+            contentTextView.topAnchor.constraint(equalTo: headerLabel.bottomAnchor, constant: 10),
+            contentTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
+            contentTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+            contentTextView.heightAnchor.constraint(equalToConstant: 200)
+        ])
+        
+        NSLayoutConstraint.activate([
+            infoLabel.topAnchor.constraint(equalTo: contentTextView.bottomAnchor, constant: 10),
+            infoLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10)
+        ])
+        
+        NSLayoutConstraint.activate([
+            reportButton.topAnchor.constraint(equalTo: infoLabel.bottomAnchor, constant: 10),
+            reportButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 10),
+            reportButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
+            reportButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+    }
+    
+    func configureNavigation() {
+        navigationItem.title = "사용자 신고"
+        navigationItem.backButtonDisplayMode = .minimal
+    }
+    
+    func bindViewModel() {
+        
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/Report/ViewModel/ReportViewModel.swift
+++ b/iOS/Village/Village/Presentation/Report/ViewModel/ReportViewModel.swift
@@ -1,0 +1,24 @@
+//
+//  ReportViewModel.swift
+//  Village
+//
+//  Created by 조성민 on 12/10/23.
+//
+
+import Foundation
+
+final class ReportViewModel {
+    
+}
+
+extension ReportViewModel {
+    
+    struct Input {
+        
+    }
+    
+    struct Output {
+        
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/Report/ViewModel/ReportViewModel.swift
+++ b/iOS/Village/Village/Presentation/Report/ViewModel/ReportViewModel.swift
@@ -6,19 +6,63 @@
 //
 
 import Foundation
+import Combine
 
 final class ReportViewModel {
+    
+    private let userID: String
+    private let postID: Int
+    
+    private let completeOutput = PassthroughSubject<Void, Never>()
+    
+    private var cancellableBag = Set<AnyCancellable>()
+    
+    init(userID: String, postID: Int) {
+        self.userID = userID
+        self.postID = postID
+    }
+    
+    func transform(input: Input) -> Output {
+        
+        input.reportButtonTapped
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] description in
+                self?.report(description: description)
+            }
+            .store(in: &cancellableBag)
+        return Output(
+            completeOutput: completeOutput.eraseToAnyPublisher()
+        )
+    }
+    
+    private func report(description: String) {
+        let endpoint = APIEndPoints.reportUser(
+            reportInfo: ReportDTO(
+                postID: postID, userID: userID, description: description
+            )
+        )
+        
+        Task {
+            do {
+                try await APIProvider.shared.request(with: endpoint)
+                completeOutput.send()
+            } catch {
+                dump(error)
+            }
+        }
+        
+    }
     
 }
 
 extension ReportViewModel {
     
     struct Input {
-        
+        let reportButtonTapped: AnyPublisher<String, Never>
     }
     
     struct Output {
-        
+        let completeOutput: AnyPublisher<Void, Never>
     }
     
 }


### PR DESCRIPTION
## 이슈
- #454

## 체크리스트
- [x]  다른 사용자를 신고할 수 있다.

## 고민한 내용
- 신고한 사용자를 차단해야 하는지 고민한 결과 다른 개시물을 보고싶을 수도 있기 때문에 자동으로 차단하는 기능은 뺐습니다.

## 스크린샷
|  ![image](https://github.com/boostcampwm2023/iOS05-Village/assets/128480641/fca575ac-d7d4-47d8-a333-2fc93df67c2b) |
| -------- |
|  ![image](https://github.com/boostcampwm2023/iOS05-Village/assets/128480641/fd991bdb-e6c3-4e4d-8ca4-741a6310c380)   |
| ![image](https://github.com/boostcampwm2023/iOS05-Village/assets/128480641/06df4f4e-0f3c-48ce-a5d5-bb9fc2fda520) |

