### PR TITLE
[iOS/#479] 내 게시글 편집/삭제 새로고침 안 되는 현상 제거

### DIFF
--- a/iOS/Village/Village/Presentation/Commons/Cell/RentPostTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/Commons/Cell/RentPostTableViewCell.swift
@@ -26,6 +26,12 @@ final class RentPostTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        postSummaryView.postImageView.image = nil
+        postSummaryView.postTitleLabel.text = nil
+        postSummaryView.postPriceLabel.text = nil
+    }
+    
     func configureData(post: PostListResponseDTO) {
         postSummaryView.postTitleLabel.text = post.title
         postSummaryView.setPrice(price: post.price)

--- a/iOS/Village/Village/Presentation/Commons/Cell/RequstPostTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/Commons/Cell/RequstPostTableViewCell.swift
@@ -26,6 +26,12 @@ final class RequestPostTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        postSummaryView.postPeriodLabel.text = nil
+        postSummaryView.postTitleLabel.text = nil
+    }
+    
     func configureData(post: PostListResponseDTO) {
         postSummaryView.postTitleLabel.text = post.title
         

--- a/iOS/Village/Village/Presentation/MyPosts/View/MyPostsViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPosts/View/MyPostsViewController.swift
@@ -69,7 +69,7 @@ final class MyPostsViewController: UIViewController {
     }()
     
     private let paginationPublisher = PassthroughSubject<Void, Never>()
-    private let togglePublisher = PassthroughSubject<Bool, Never>()
+    private let refreshPublisher = PassthroughSubject<Bool, Never>()
     private var cancellableBag = Set<AnyCancellable>()
     
     init(viewModel: ViewModel) {
@@ -91,7 +91,7 @@ final class MyPostsViewController: UIViewController {
     }
     
     @objc private func segmentedControlChanged() {
-        togglePublisher.send(requestSegmentedControl.selectedSegmentIndex == 1)
+        refreshPublisher.send(requestSegmentedControl.selectedSegmentIndex == 1)
     }
     
 }
@@ -101,7 +101,7 @@ private extension MyPostsViewController {
     func bindViewModel() {
         let output = viewModel.transform(input: MyPostsViewModel.Input(
             nextPageUpdateSubject: paginationPublisher.eraseToAnyPublisher(),
-            toggleSubject: togglePublisher.eraseToAnyPublisher()
+            refreshSubject: refreshPublisher.eraseToAnyPublisher()
         ))
         
         output.nextPageUpdateOutput
@@ -114,7 +114,7 @@ private extension MyPostsViewController {
             }
             .store(in: &cancellableBag)
         
-        output.toggleUpdateOutput
+        output.refreshOutput
             .receive(on: DispatchQueue.main)
             .sink { [weak self] posts in
                 if posts.isEmpty {
@@ -208,7 +208,7 @@ extension MyPostsViewController: UITableViewDelegate {
         nextVC.refreshPreviousViewController
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.togglePublisher.send(self?.requestSegmentedControl.selectedSegmentIndex == 1)
+                self?.refreshPublisher.send(self?.requestSegmentedControl.selectedSegmentIndex == 1)
             }
             .store(in: &cancellableBag)
         nextVC.hidesBottomBarWhenPushed = true

--- a/iOS/Village/Village/Presentation/MyPosts/ViewModel/MyPostsViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyPosts/ViewModel/MyPostsViewModel.swift
@@ -14,8 +14,8 @@ final class MyPostsViewModel {
     
     private var requestFilter: String = "0"
     
-    private var nextPageUpdateOutput = PassthroughSubject<[PostListResponseDTO], Never>()
-    private var toggleOutput = PassthroughSubject<[PostListResponseDTO], Never>()
+    private let nextPageUpdateOutput = PassthroughSubject<[PostListResponseDTO], Never>()
+    private let toggleOutput = PassthroughSubject<[PostListResponseDTO], Never>()
     
     private var cancellableBag = Set<AnyCancellable>()
     
@@ -91,15 +91,15 @@ final class MyPostsViewModel {
     
     struct Input {
         
-        var nextPageUpdateSubject: AnyPublisher<Void, Never>
-        var toggleSubject: AnyPublisher<Void, Never>
+        let nextPageUpdateSubject: AnyPublisher<Void, Never>
+        let toggleSubject: AnyPublisher<Void, Never>
         
     }
     
     struct Output {
         
-        var nextPageUpdateOutput: AnyPublisher<[PostListResponseDTO], Never>
-        var toggleUpdateOutput: AnyPublisher<[PostListResponseDTO], Never>
+        let nextPageUpdateOutput: AnyPublisher<[PostListResponseDTO], Never>
+        let toggleUpdateOutput: AnyPublisher<[PostListResponseDTO], Never>
         
     }
     

--- a/iOS/Village/Village/Presentation/MyPosts/ViewModel/MyPostsViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyPosts/ViewModel/MyPostsViewModel.swift
@@ -15,7 +15,7 @@ final class MyPostsViewModel {
     private var requestFilter: String = "0"
     
     private let nextPageUpdateOutput = PassthroughSubject<[PostListResponseDTO], Never>()
-    private let toggleOutput = PassthroughSubject<[PostListResponseDTO], Never>()
+    private let refreshOutput = PassthroughSubject<[PostListResponseDTO], Never>()
     
     private var cancellableBag = Set<AnyCancellable>()
     
@@ -36,7 +36,7 @@ final class MyPostsViewModel {
             do {
                 guard let data = try await APIProvider.shared.request(with: endpoint) else { return }
                 posts = data
-                toggleOutput.send(data)
+                refreshOutput.send(data)
             } catch {
                 dump(error)
             }
@@ -74,7 +74,7 @@ final class MyPostsViewModel {
             }
             .store(in: &cancellableBag)
         
-        input.toggleSubject
+        input.refreshSubject
             .sink { [weak self] isRequest in
                 self?.requestFilter = isRequest ? "1" : "0"
                 self?.updateInitPosts()
@@ -83,21 +83,21 @@ final class MyPostsViewModel {
         
         return Output(
             nextPageUpdateOutput: nextPageUpdateOutput.eraseToAnyPublisher(),
-            toggleUpdateOutput: toggleOutput.eraseToAnyPublisher()
+            refreshOutput: refreshOutput.eraseToAnyPublisher()
         )
     }
     
     struct Input {
         
         let nextPageUpdateSubject: AnyPublisher<Void, Never>
-        let toggleSubject: AnyPublisher<Bool, Never>
+        let refreshSubject: AnyPublisher<Bool, Never>
         
     }
     
     struct Output {
         
         let nextPageUpdateOutput: AnyPublisher<[PostListResponseDTO], Never>
-        let toggleUpdateOutput: AnyPublisher<[PostListResponseDTO], Never>
+        let refreshOutput: AnyPublisher<[PostListResponseDTO], Never>
         
     }
     

--- a/iOS/Village/Village/Presentation/MyPosts/ViewModel/MyPostsViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyPosts/ViewModel/MyPostsViewModel.swift
@@ -35,10 +35,8 @@ final class MyPostsViewModel {
         Task {
             do {
                 guard let data = try await APIProvider.shared.request(with: endpoint) else { return }
-                if posts.last != data.last {
-                    posts = data
-                    toggleOutput.send(data)
-                }
+                posts = data
+                toggleOutput.send(data)
             } catch {
                 dump(error)
             }
@@ -77,8 +75,8 @@ final class MyPostsViewModel {
             .store(in: &cancellableBag)
         
         input.toggleSubject
-            .sink { [weak self] in
-                self?.requestFilter = self?.requestFilter == "0" ? "1" : "0"
+            .sink { [weak self] isRequest in
+                self?.requestFilter = isRequest ? "1" : "0"
                 self?.updateInitPosts()
             }
             .store(in: &cancellableBag)
@@ -92,7 +90,7 @@ final class MyPostsViewModel {
     struct Input {
         
         let nextPageUpdateSubject: AnyPublisher<Void, Never>
-        let toggleSubject: AnyPublisher<Void, Never>
+        let toggleSubject: AnyPublisher<Bool, Never>
         
     }
     

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -20,6 +20,8 @@ final class PostDetailViewController: UIViewController {
     private let hidePost = PassthroughSubject<Int, Never>()
     private let blockUser = PassthroughSubject<String, Never>()
     
+    let refreshPreviousViewController = PassthroughSubject<Void, Never>()
+    
     private let viewModel = ViewModel()
     private var cancellableBag = Set<AnyCancellable>()
     
@@ -342,6 +344,7 @@ private extension PostDetailViewController {
                     dump(error)
                 }
             }, receiveValue: { [weak self] in
+                self?.refreshPreviousViewController.send()
                 self?.navigationController?.popViewController(animated: true)
             })
             .store(in: &cancellableBag)
@@ -356,10 +359,11 @@ private extension PostDetailViewController {
                     dump(error)
                 }
             }, receiveValue: { [weak self] in
+                self?.refreshPreviousViewController.send()
                 self?.navigationController?.popViewController(animated: true)
             })
             .store(in: &cancellableBag)
-        
+    
     }
     
     private func bindUserOutput(_ output: ViewModel.UserOutput) {

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -126,6 +126,7 @@ final class PostDetailViewController: UIViewController {
                 .sink { [weak self] in
                     guard let id = self?.postID.output else { return }
                     self?.viewModel.getPost(id: id)
+                    self?.refreshPreviousViewController.send()
                 }
                 .store(in: &editVC.cancellableBag)
             let editNC = UINavigationController(rootViewController: editVC)


### PR DESCRIPTION
## 이슈
- #479

## 체크리스트
- [x] 삭제, 편집 시에만 새로고침을 해야한다.

## 고민한 내용
- 삭제, 편집시에 바깥 뷰컨에서 새로고침을 할 수 있도록 Combine을 사용했습니다.
- Cell이 재사용 될 때 이미지 로딩에 시간차가 생겨 다른 이미지가 잠시 나오는 현상이 있었는데 prepareForReuse를 통해 해결했습니다.
