### PR TITLE
[iOS/#486] 검색결과 페이지네이션 요청 계속가는 버그 수정 

### DIFF
--- a/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
@@ -256,7 +256,7 @@ private extension HomeViewController {
     }
     
     @objc func searchButtonTapped() {
-        let nextVC = SearchViewController()
+        let nextVC = SearchResultViewController()
         nextVC.hidesBottomBarWhenPushed = true
         self.navigationController?.pushViewController(nextVC, animated: false)
     }

--- a/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
@@ -76,8 +76,6 @@ final class SearchResultViewController: UIViewController {
         definesPresentationContext = true
 
         setUI()
-        generateData()
-        bindViewModel()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -133,7 +131,7 @@ extension SearchResultViewController {
     
     private func bindViewModel() {
         let input = ViewModel.Input(
-            postTitle: self.titlePublisher.eraseToAnyPublisher(),
+            postTitle: Just(self.postTitle).eraseToAnyPublisher(),
             toggleSubject: self.togglePublisher.eraseToAnyPublisher(),
             scrollEvent: self.scrollPublisher.eraseToAnyPublisher()
         )
@@ -198,6 +196,7 @@ extension SearchResultViewController: UISearchResultsUpdating, UISearchBarDelega
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         generateData()
+        bindViewModel()
         titlePublisher.send(self.postTitle)
         self.requestSegmentedControl.isHidden = false
         self.listTableView.isHidden = false

--- a/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
@@ -83,8 +83,10 @@ final class SearchResultViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        self.requestSegmentedControl.isHidden = true
-        self.listTableView.isHidden = true
+        if postTitle == "" {
+            self.requestSegmentedControl.isHidden = true
+            self.listTableView.isHidden = true
+        }
     }
 
 }

--- a/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
@@ -24,6 +24,7 @@ final class SearchResultViewController: UIViewController {
     private var cancellableBag = Set<AnyCancellable>()
     
     private var postTitle: String = ""
+    private var paginationFlag: Bool = true
     
     private lazy var requestSegmentedControl: UISegmentedControl = {
         let control = UISegmentedControl(items: ["대여", "요청"])
@@ -146,6 +147,7 @@ extension SearchResultViewController {
                     dump(error)
                 }
             } receiveValue: { [weak self] postList in
+                self?.paginationFlag = false
                 self?.addGenerateData(list: postList)
             }
             .store(in: &cancellableBag)
@@ -173,7 +175,8 @@ extension SearchResultViewController {
 extension SearchResultViewController: UITableViewDelegate {
     
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView.contentOffset.y > self.listTableView.contentSize.height - 1000 {
+        if scrollView.contentOffset.y > self.listTableView.contentSize.height - 1000
+        && paginationFlag {
             scrollPublisher.send()
         }
     }

--- a/iOS/Village/Village/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
@@ -78,11 +78,14 @@ final class SearchResultViewModel {
             do {
                 guard let data = try await APIProvider.shared.request(with: endpoint),
                       let lastID = data.last?.postID
-                else { return }
+                else {
+                    searchResultList.send([])
+                    return
+                }
                 searchResultList.send(data)
                 self.lastPostID = "\(lastID)"
             } catch {
-                dump(error)
+                searchResultList.send(completion: .failure(NetworkError.urlRequestError))
             }
         }
     }


### PR DESCRIPTION
## 이슈
- #486 

## 체크리스트
- [x] 검색결과 페이지네이션 요청 계속가는 버그 수정 
- [x] 검색결과에서 상세화면 클릭 후, 뒤로가면 결과 사라지는 버그 수정
