### PR TITLE
[iOS/#504] 유저 탈퇴 관련 이슈 구현

### DIFF
--- a/iOS/Village/Village/Presentation/PostDetail/Custom/UserInfoView.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/UserInfoView.swift
@@ -37,9 +37,10 @@ final class UserInfoView: UIView {
         fatalError("Should not be called")
     }
     
-    func setContent(imageURL: String, nickname: String) {
+    func setContent(imageURL: String?, nickname: String) {
         Task {
             do {
+                guard let imageURL = imageURL else { return }
                 let data = try await APIProvider.shared.request(from: imageURL)
                 profileImageView.image = UIImage(data: data)
             } catch let error {

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -331,9 +331,12 @@ private extension PostDetailViewController {
                     break
                 case .failure(_):
                     self.setUserContent(user: nil)
+                    self.chatButton.isEnabled = false
+                    self.chatButton.backgroundColor = .userChatMessage
                 }
             } receiveValue: { [weak self] user in
                 self?.setUserContent(user: user)
+                self?.chatButton.backgroundColor = .primary500
             }
             .store(in: &cancellableBag)
     }    

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -246,8 +246,12 @@ final class PostDetailViewController: UIViewController {
         priceLabel.setPrice(price: post.price)
     }
     
-    private func setUserContent(user: UserResponseDTO) {
-        userInfoView.setContent(imageURL: user.profileImageURL, nickname: user.nickname)
+    private func setUserContent(user: UserResponseDTO?) {
+        if let user = user {
+            userInfoView.setContent(imageURL: user.profileImageURL, nickname: user.nickname)
+        } else {
+            userInfoView.setContent(imageURL: nil, nickname: "(알 수 없음)")
+        }
     }
 
 }
@@ -325,8 +329,8 @@ private extension PostDetailViewController {
                 switch completion {
                 case .finished:
                     break
-                case .failure(let error):
-                    dump(error)
+                case .failure(_):
+                    self.setUserContent(user: nil)
                 }
             } receiveValue: { [weak self] user in
                 self?.setUserContent(user: user)

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -250,7 +250,7 @@ final class PostDetailViewController: UIViewController {
         if let user = user {
             userInfoView.setContent(imageURL: user.profileImageURL, nickname: user.nickname)
         } else {
-            userInfoView.setContent(imageURL: nil, nickname: "(알 수 없음)")
+            userInfoView.setContent(imageURL: nil, nickname: "(탈퇴한 회원)")
         }
     }
 

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -329,7 +329,7 @@ private extension PostDetailViewController {
                 switch completion {
                 case .finished:
                     break
-                case .failure(_):
+                case .failure(_:):
                     self.setUserContent(user: nil)
                     self.chatButton.isEnabled = false
                     self.chatButton.backgroundColor = .userChatMessage


### PR DESCRIPTION
## 이슈
- #504 

## 체크리스트
- [x] 닉네임을 (알 수 없음)으로 변경
- [x] 채팅하기 버튼 숨기기

## 고민한 내용
- 프로필사진 부분을 공백처리를 해도될지 모르겠지만 나쁘진 않은것같다.

## 스크린샷
<img src=https://github.com/boostcampwm2023/iOS05-Village/assets/59719500/7d1154f0-80d3-48a7-b6fb-c9bdd60928fa width=300 />
