### PR TITLE
[iOS/#501] 게시글 숨김 처리 했을 때 새로고침 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -36,7 +36,8 @@
 		446B60FB2B220DC400A361CB /* ImageUploadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B60FA2B220DC400A361CB /* ImageUploadView.swift */; };
 		446B61002B2433E100A361CB /* ImageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B60FF2B2433E100A361CB /* ImageItem.swift */; };
 		446B61062B2602A200A361CB /* PostSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B61052B2602A200A361CB /* PostSegmentedControl.swift */; };
-		446B610B2B26439D00A361CB /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B610A2B26439D00A361CB /* Post.swift */; };
+		446B610B2B26439D00A361CB /* PostType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B610A2B26439D00A361CB /* PostType.swift */; };
+		446B61142B275C2900A361CB /* PostNotificationPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 446B61132B275C2900A361CB /* PostNotificationPublisher.swift */; };
 		4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4491AA272B05D6C90016FC70 /* MenuView.swift */; };
 		44C1F5E62B0FE37C0047A436 /* PostDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C1F5E52B0FE37C0047A436 /* PostDetailViewModel.swift */; };
 		44C1F5ED2B0FE44A0047A436 /* UserResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C1F5EC2B0FE44A0047A436 /* UserResponseDTO.swift */; };
@@ -171,7 +172,8 @@
 		446B60FA2B220DC400A361CB /* ImageUploadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageUploadView.swift; sourceTree = "<group>"; };
 		446B60FF2B2433E100A361CB /* ImageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageItem.swift; sourceTree = "<group>"; };
 		446B61052B2602A200A361CB /* PostSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSegmentedControl.swift; sourceTree = "<group>"; };
-		446B610A2B26439D00A361CB /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
+		446B610A2B26439D00A361CB /* PostType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostType.swift; sourceTree = "<group>"; };
+		446B61132B275C2900A361CB /* PostNotificationPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNotificationPublisher.swift; sourceTree = "<group>"; };
 		4491AA272B05D6C90016FC70 /* MenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuView.swift; sourceTree = "<group>"; };
 		44C1F5E52B0FE37C0047A436 /* PostDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailViewModel.swift; sourceTree = "<group>"; };
 		44C1F5EC2B0FE44A0047A436 /* UserResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponseDTO.swift; sourceTree = "<group>"; };
@@ -292,7 +294,8 @@
 		440FCC2B2B04EB830011B637 /* Common */ = {
 			isa = PBXGroup;
 			children = (
-				446B610A2B26439D00A361CB /* Post.swift */,
+				446B610A2B26439D00A361CB /* PostType.swift */,
+				446B61132B275C2900A361CB /* PostNotificationPublisher.swift */,
 				59110F032B1725C20009E9AC /* NotificationName+.swift */,
 				446362CA2B0DFD4F00B74DA7 /* Int+.swift */,
 				440FCC2C2B04EB940011B637 /* Constants.swift */,
@@ -1175,6 +1178,7 @@
 				444A50902B0C60F900454397 /* ImagePageView.swift in Sources */,
 				59110EFB2B15F3D60009E9AC /* ChatRoomTableViewCell.swift in Sources */,
 				444A50942B0C8D1900454397 /* UIView+Divider.swift in Sources */,
+				446B61142B275C2900A361CB /* PostNotificationPublisher.swift in Sources */,
 				8FBB65CE2B20C21100C6A133 /* GetChatListResponseDTO.swift in Sources */,
 				59D4DBE22B068C6400BBA2D5 /* UIView+Layer.swift in Sources */,
 				446362C92B0DF9E800B74DA7 /* PriceLabel.swift in Sources */,
@@ -1215,7 +1219,7 @@
 				4416D44A2B148A7A0052BF33 /* AppTabBarController.swift in Sources */,
 				8FF7E61D2B10721400B6D678 /* ChatListViewModel.swift in Sources */,
 				8FD52A482B09D1AD005EE367 /* MyPageViewController.swift in Sources */,
-				446B610B2B26439D00A361CB /* Post.swift in Sources */,
+				446B610B2B26439D00A361CB /* PostType.swift in Sources */,
 				8F3D79E02B136C6800370536 /* ChatRoomViewModel.swift in Sources */,
 				44C1F5ED2B0FE44A0047A436 /* UserResponseDTO.swift in Sources */,
 				446B60F92B220D9500A361CB /* ImageViewCell.swift in Sources */,

--- a/iOS/Village/Village/Common/NotificationName+.swift
+++ b/iOS/Village/Village/Common/NotificationName+.swift
@@ -16,5 +16,6 @@ extension Notification.Name {
     static let postEdited = Notification.Name("PostEdited")
     static let postDeleted = Notification.Name("PostDeleted")
     static let postCreated = Notification.Name("PostCreated")
+    static let postHiddenChanged = Notification.Name("PostHiddenChanged")
   
 }

--- a/iOS/Village/Village/Common/PostNotificationPublisher.swift
+++ b/iOS/Village/Village/Common/PostNotificationPublisher.swift
@@ -1,0 +1,35 @@
+//
+//  PostNotificationPublisher.swift
+//  Village
+//
+//  Created by 정상윤 on 12/12/23.
+//
+
+import Foundation
+
+final class PostNotificationPublisher {
+    
+    static let shared = PostNotificationPublisher()
+    
+    private let center: NotificationCenter
+    
+    init(center: NotificationCenter = .default) {
+        self.center = center
+    }
+    
+    func publishPostCreated(isRequest: Bool) {
+        let info = ["type": PostType(isRequest: isRequest)]
+        center.post(name: .postCreated, object: nil, userInfo: info)
+    }
+    
+    func publishPostEdited(postID: Int) {
+        let info = ["postID": postID]
+        NotificationCenter.default.post(name: .postEdited, object: nil, userInfo: info)
+    }
+    
+    func publishPostDeleted(postID: Int) {
+        let info = ["postID": postID]
+        NotificationCenter.default.post(name: .postDeleted, object: nil, userInfo: info)
+    }
+    
+}

--- a/iOS/Village/Village/Common/PostNotificationPublisher.swift
+++ b/iOS/Village/Village/Common/PostNotificationPublisher.swift
@@ -32,4 +32,8 @@ final class PostNotificationPublisher {
         NotificationCenter.default.post(name: .postDeleted, object: nil, userInfo: info)
     }
     
+    func publishPostHiddenChanged() {
+        NotificationCenter.default.post(name: .postHiddenChanged, object: nil)
+    }
+    
 }

--- a/iOS/Village/Village/Common/PostType.swift
+++ b/iOS/Village/Village/Common/PostType.swift
@@ -1,5 +1,5 @@
 //
-//  Post.swift
+//  PostType.swift
 //  Village
 //
 //  Created by 정상윤 on 12/11/23.
@@ -10,4 +10,8 @@ import Foundation
 enum PostType {
     case rent
     case request
+    
+    init(isRequest: Bool) {
+        self = isRequest ? .request : .rent
+    }
 }

--- a/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
@@ -16,7 +16,12 @@ final class HomeViewController: UIViewController {
     typealias ViewModel = HomeViewModel
     typealias Input = ViewModel.Input
     
-    private var postType: PostType = .rent
+    private var postType: PostType = .rent {
+        didSet {
+            postSegmentedControl.selectedSegmentIndex = (postType == .rent) ? 0 : 1
+            setContainerViewPosition()
+        }
+    }
     private let refresh = CurrentValueSubject<PostType, Never>(.rent)
     private let pagination = PassthroughSubject<PostType, Never>()
     private var paginationFlag: Bool = true
@@ -174,7 +179,8 @@ final class HomeViewController: UIViewController {
     private func handleCreatedPost(output: ViewModel.Output) {
         output.createdPost
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] postType in
+                self?.postType = postType
                 self?.refreshPost()
             }
             .store(in: &cancellableBag)
@@ -214,9 +220,7 @@ private extension HomeViewController {
         }
     }
     
-    func togglePostType() {
-        postType = (postType == .rent) ? .request : .rent
-        
+    func setContainerViewPosition() {
         switch postType {
         case .rent:
             containerViewLeadingConstraint.constant = 0
@@ -227,6 +231,10 @@ private extension HomeViewController {
         if requestDataSource.snapshot().numberOfItems == 0 {
             refresh.send(postType)
         }
+    }
+    
+    func togglePostType() {
+        postType = (postType == .rent) ? .request : .rent
         
     }
     

--- a/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
+++ b/iOS/Village/Village/Presentation/Home/View/HomeViewController.swift
@@ -235,7 +235,6 @@ private extension HomeViewController {
     
     func togglePostType() {
         postType = (postType == .rent) ? .request : .rent
-        
     }
     
     func searchButtonTapped() {

--- a/iOS/Village/Village/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/iOS/Village/Village/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -18,6 +18,7 @@ final class HomeViewModel {
     private let createdPost = PassthroughSubject<PostType, Never>()
     private let deletedPost = PassthroughSubject<Int, Never>()
     private let editedPost = PassthroughSubject<Post, Never>()
+    private let hiddenChanged = PassthroughSubject<Void, Never>()
     
     private var lastRentPostID: String?
     private var lastRequestPostID: String?
@@ -30,7 +31,8 @@ final class HomeViewModel {
             postList: postList.eraseToAnyPublisher(),
             createdPost: createdPost.eraseToAnyPublisher(),
             deletedPost: deletedPost.eraseToAnyPublisher(),
-            editedPost: editedPost.eraseToAnyPublisher()
+            editedPost: editedPost.eraseToAnyPublisher(),
+            hiddenChanged: hiddenChanged.eraseToAnyPublisher()
         )
     }
     
@@ -69,6 +71,10 @@ final class HomeViewModel {
                                                selector: #selector(handlePostDeleted(notification:)),
                                                name: .postDeleted,
                                                object: nil)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(handleHiddenChanged),
+                                               name: .postHiddenChanged,
+                                               object: nil)
     }
     
 }
@@ -101,6 +107,10 @@ private extension HomeViewModel {
         guard let postID = notification.userInfo?["postID"] as? Int else { return }
         
         deletedPost.send(postID)
+    }
+    
+    func handleHiddenChanged() {
+        hiddenChanged.send()
     }
     
 }
@@ -189,6 +199,7 @@ extension HomeViewModel {
         let createdPost: AnyPublisher<PostType, Never>
         let deletedPost: AnyPublisher<Int, Never>
         let editedPost: AnyPublisher<Post, Never>
+        let hiddenChanged: AnyPublisher<Void, Never>
     }
     
 }

--- a/iOS/Village/Village/Presentation/Home/ViewModel/HomeViewModel.swift
+++ b/iOS/Village/Village/Presentation/Home/ViewModel/HomeViewModel.swift
@@ -15,7 +15,7 @@ final class HomeViewModel {
     private var cancellableBag = Set<AnyCancellable>()
     
     private let postList = PassthroughSubject<[Post], Error>()
-    private let createdPost = PassthroughSubject<Void, Never>()
+    private let createdPost = PassthroughSubject<PostType, Never>()
     private let deletedPost = PassthroughSubject<Int, Never>()
     private let editedPost = PassthroughSubject<Post, Never>()
     
@@ -62,7 +62,7 @@ final class HomeViewModel {
                                                object: nil)
         
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(handlePostCreated),
+                                               selector: #selector(handlePostCreated(notification:)),
                                                name: .postCreated,
                                                object: nil)
         NotificationCenter.default.addObserver(self,
@@ -91,8 +91,10 @@ private extension HomeViewModel {
         }
     }
     
-    func handlePostCreated() {
-        createdPost.send()
+    func handlePostCreated(notification: Notification) {
+        guard let postType = notification.userInfo?["type"] as? PostType else { return }
+        
+        createdPost.send(postType)
     }
     
     func handlePostDeleted(notification: Notification) {
@@ -184,7 +186,7 @@ extension HomeViewModel {
     
     struct Output {
         let postList: AnyPublisher<[Post], Error>
-        let createdPost: AnyPublisher<Void, Never>
+        let createdPost: AnyPublisher<PostType, Never>
         let deletedPost: AnyPublisher<Int, Never>
         let editedPost: AnyPublisher<Post, Never>
     }

--- a/iOS/Village/Village/Presentation/MyHiddenPosts/ViewModel/MyHiddenPostsViewModel.swift
+++ b/iOS/Village/Village/Presentation/MyHiddenPosts/ViewModel/MyHiddenPostsViewModel.swift
@@ -49,6 +49,10 @@ final class MyHiddenPostsViewModel {
         getMyHiddenPosts()
     }
     
+    deinit {
+        PostNotificationPublisher.shared.publishPostHiddenChanged()
+    }
+    
     private func getMyHiddenPosts() {        
         let endpoint = APIEndPoints.getHiddenPosts(
             requestFilter: RequestFilterDTO(
@@ -78,7 +82,6 @@ final class MyHiddenPostsViewModel {
                 dump(error)
             }
         }
-        
     }
     
 }

--- a/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/ViewModel/PostCreateViewModel.swift
@@ -95,9 +95,9 @@ final class PostCreateViewModel {
             do {
                 try await APIProvider.shared.request(with: modifyEndPoint)
                 if let id = postID {
-                    NotificationCenter.default.post(name: .postEdited, object: nil, userInfo: ["postID": id])
+                    PostNotificationPublisher.shared.publishPostEdited(postID: id)
                 } else {
-                    NotificationCenter.default.post(name: .postCreated, object: nil)
+                    PostNotificationPublisher.shared.publishPostCreated(isRequest: isRequest)
                 }
                 endOutput.send()
             } catch let error as NetworkError {

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -111,7 +111,7 @@ final class PostDetailViewModel {
         Task {
             do {
                 try await APIProvider.shared.request(with: endpoint)
-                NotificationCenter.default.post(name: .postDeleted, object: nil, userInfo: ["postID": postID])
+                PostNotificationPublisher.shared.publishPostDeleted(postID: postID)
                 deleteOutput.send()
             } catch let error as NetworkError {
                 deleteOutput.send(completion: .failure(error))
@@ -125,6 +125,7 @@ final class PostDetailViewModel {
         Task {
             do {
                 try await APIProvider.shared.request(with: endpoint)
+                PostNotificationPublisher.shared.publishPostDeleted(postID: postID)
                 popViewControllerOutput.send()
             } catch let error as NetworkError {
                 popViewControllerOutput.send(completion: .failure(error))


### PR DESCRIPTION
## 이슈
- #501 

## 체크리스트
- [x] 게시글 작성 시 해당 게시글 종류 테이블뷰 넘어가도록 구현
- [x] 특정 게시글 숨김 시 홈에서 셀 삭제 구현
- [x] 마이페이지 숨김 게시글 화면에서 벗어났을 때 홈에서 새로고침하도록 구현

## 고민한 내용
- 마이페이지에서 게시글 숨김에 대한 변경이 일어났을 때, 홈에서 새로고침을 어떻게 해줘야할지에 대해 고민이 있었습니다.
- 현재는 게시글 숨김 화면이 dismiss 됐을 때 홈에서 대여/요청 모두 새로고침이 일어나도록 구현했습니다.

## 스크린샷
없음