### PR TITLE
[BE/#524] 탈퇴한 사용자도 차단할 수 있도록 수정

### DIFF
--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -50,6 +50,7 @@ export class PostService {
       await this.blockUserRepository.find({
         where: { blocker: userId },
         relations: ['blockedUser'],
+        withDeleted: true,
       })
     ).map((blockedUser) => blockedUser.blockedUser.user_hash);
 

--- a/BE/src/users-block/users-block.service.ts
+++ b/BE/src/users-block/users-block.service.ts
@@ -18,6 +18,7 @@ export class UsersBlockService {
   async addBlockUser(id: string, userId: string) {
     const isExistUser = await this.userRepository.findOne({
       where: { user_hash: id },
+      withDeleted: true,
     });
 
     if (!isExistUser) {

--- a/BE/src/users-block/users-block.service.ts
+++ b/BE/src/users-block/users-block.service.ts
@@ -5,6 +5,12 @@ import { Repository } from 'typeorm';
 import { UserEntity } from 'src/entities/user.entity';
 import { ConfigService } from '@nestjs/config';
 
+interface BlockedUser {
+  user_id: string;
+  nickname?: string;
+  profile_img?: string;
+}
+
 @Injectable()
 export class UsersBlockService {
   constructor(
@@ -52,15 +58,19 @@ export class UsersBlockService {
     });
 
     const blockedUsers = res.reduce((acc, cur) => {
-      const user = {
-        nickname: cur.blockedUser.nickname,
-        profile_img:
+      const user: BlockedUser = {
+        user_id: cur.blocked_user,
+      };
+      if (cur.blockedUser === null) {
+        user.nickname = null;
+        user.profile_img = null;
+      } else {
+        user.nickname = cur.blockedUser.nickname;
+        user.profile_img =
           cur.blockedUser.profile_img === null
             ? this.configService.get('DEFAULT_PROFILE_IMAGE')
-            : cur.blockedUser.profile_img,
-        user_id: cur.blockedUser.user_hash,
-      };
-
+            : cur.blockedUser.profile_img;
+      }
       acc.push(user);
       return acc;
     }, []);

--- a/BE/src/users/users.service.ts
+++ b/BE/src/users/users.service.ts
@@ -73,7 +73,6 @@ export class UsersService {
   async deleteCascadingUser(userId, userHash) {
     await this.blockPostRepository.softDelete({ blocker: userHash });
     await this.blockUserRepository.softDelete({ blocker: userHash });
-    await this.blockUserRepository.softDelete({ blocked_user: userHash });
     await this.userRepository.softDelete({ id: userId });
   }
 


### PR DESCRIPTION
## 이슈
- #524

## 체크리스트
- [x] 탈퇴한 사용자도 차단할 수 있도록 수정
- [x] 삭제된 유저를 차단한 것에 대해서도 게시글 필터링
- [x] 탈퇴한 회원에 대해서도 차단 가능하도록 수정
- [x] 탈퇴한 회원을 차단후 조회했을 때 null 반환하게 수정

## 고민한 내용
- 탈퇴한 사용자에 대해 조회될 때 null 값으로 어떻게 줄지 고민한결과 조인 된게 있는지 확인하여 처리 했다.

## 스크린샷
