### PR TITLE
[iOS/#518] 탈퇴한 회원 신고, 차단

### DIFF
--- a/iOS/Village/Village/Domain/Network/BlockedUserDTO.swift
+++ b/iOS/Village/Village/Domain/Network/BlockedUserDTO.swift
@@ -9,8 +9,8 @@ import Foundation
 
 struct BlockedUserDTO: Decodable, Hashable {
     
-    let nickname: String
-    let profileImageURL: String
+    let nickname: String?
+    let profileImageURL: String?
     let userID: String
     
     enum CodingKeys: String, CodingKey {

--- a/iOS/Village/Village/Presentation/BlockedUser/View/BlockedUserTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/BlockedUser/View/BlockedUserTableViewCell.swift
@@ -124,6 +124,7 @@ final class BlockedUserTableViewCell: UITableViewCell {
     func configureData(user: BlockedUserDTO) {
         guard let nickname = user.nickname, let imageURL = user.profileImageURL else {
             nicknameLabel.text = "(탈퇴한 회원)"
+            profileImageView.backgroundColor = .black
             return
         }
         configureImage(url: imageURL)

--- a/iOS/Village/Village/Presentation/BlockedUser/View/BlockedUserTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/BlockedUser/View/BlockedUserTableViewCell.swift
@@ -116,8 +116,12 @@ final class BlockedUserTableViewCell: UITableViewCell {
     }
     
     func configureData(user: BlockedUserDTO) {
-        configureImage(url: user.profileImageURL)
-        nicknameLabel.text = user.nickname
+        guard let nickname = user.nickname, let imageURL = user.profileImageURL else {
+            nicknameLabel.text = "(탈퇴한 회원)"
+            return
+        }
+        configureImage(url: imageURL)
+        nicknameLabel.text = nickname
     }
     
     func configureImage(url: String) {

--- a/iOS/Village/Village/Presentation/BlockedUser/View/BlockedUserTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/BlockedUser/View/BlockedUserTableViewCell.swift
@@ -87,6 +87,13 @@ final class BlockedUserTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        profileImageView.image = nil
+        nicknameLabel.text = nil
+        blockedButton.configuration?.baseBackgroundColor = .primary500
+        blockedButton.configuration?.attributedTitle = unblockTitleString
+    }
+    
     private func setUI() {
         self.contentView.addSubview(profileImageView)
         self.contentView.addSubview(nicknameLabel)

--- a/iOS/Village/Village/Presentation/BlockedUser/View/BlockedUserTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/BlockedUser/View/BlockedUserTableViewCell.swift
@@ -80,6 +80,7 @@ final class BlockedUserTableViewCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setUI()
+        configureConstraints()
     }
     
     required init?(coder: NSCoder) {
@@ -90,8 +91,6 @@ final class BlockedUserTableViewCell: UITableViewCell {
         self.contentView.addSubview(profileImageView)
         self.contentView.addSubview(nicknameLabel)
         self.contentView.addSubview(blockedButton)
-        
-        configureConstraints()
     }
     
     private func configureConstraints() {
@@ -124,7 +123,7 @@ final class BlockedUserTableViewCell: UITableViewCell {
         nicknameLabel.text = nickname
     }
     
-    func configureImage(url: String) {
+    private func configureImage(url: String) {
         Task {
             do {
                 let data = try await APIProvider.shared.request(from: url)

--- a/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
+++ b/iOS/Village/Village/Presentation/Report/View/ReportViewController.swift
@@ -106,6 +106,7 @@ final class ReportViewController: UIViewController {
     
     @objc private func reportButtonTapped() {
         reportSubject.send(contentTextView.text)
+        reportButton.isUserInteractionEnabled = false
     }
     
 }


### PR DESCRIPTION
## 이슈
- #518

## 체크리스트
- [x] 탈퇴한 사용자를 신고할 수 있어야 한다.

## 고민한 내용
- 탈퇴한 사용자를 신고하거나 차단하면 앱이 터지는 현상 발생 -> 서버 문제로 서버와 협의하여 DTO 수정
- 탈퇴한 사용자를 차단하면 차단 목록에서 받아올 때 nil 로 받아와야 하기 때문에 nil인경우 처리함
