### PR TITLE
[iOS/#516] 검색 결과 버그 수정

### DIFF
--- a/iOS/Village/Village/Presentation/SearchResult/View/SearchRentTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/View/SearchRentTableViewCell.swift
@@ -26,6 +26,14 @@ class SearchRentTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        postSummaryView.postImageView.image = nil
+        postSummaryView.postTitleLabel.text = nil
+        postSummaryView.postPriceLabel.text = nil
+        postSummaryView.postAccessoryView.image = nil
+    }
+    
     func configureData(post: PostResponseDTO) {
         postSummaryView.postTitleLabel.text = post.title
         postSummaryView.setPrice(price: post.price)

--- a/iOS/Village/Village/Presentation/SearchResult/View/SearchRentTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/View/SearchRentTableViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SearchRentTableViewCell: UITableViewCell {
+final class SearchRentTableViewCell: UITableViewCell {
 
     private let postSummaryView: RentPostSummaryView = {
         let view = RentPostSummaryView()

--- a/iOS/Village/Village/Presentation/SearchResult/View/SearchRequstTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/View/SearchRequstTableViewCell.swift
@@ -26,6 +26,13 @@ class SearchRequstTableViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        postSummaryView.postPeriodLabel.text = nil
+        postSummaryView.postTitleLabel.text = nil
+        postSummaryView.postAccessoryView.image = nil
+    }
+    
     func configureData(post: PostResponseDTO) {
         postSummaryView.postTitleLabel.text = post.title
         

--- a/iOS/Village/Village/Presentation/SearchResult/View/SearchRequstTableViewCell.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/View/SearchRequstTableViewCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SearchRequstTableViewCell: UITableViewCell {
+final class SearchRequstTableViewCell: UITableViewCell {
 
     private let postSummaryView: RequestPostSummaryView = {
         let view = RequestPostSummaryView()

--- a/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
@@ -103,6 +103,7 @@ extension SearchResultViewController {
     
     private func setNavigationBarUI() {
         searchController.searchBar.text = self.postTitle
+        searchController.searchBar.placeholder = "검색어를 입력해주세요."
         searchController.searchBar.frame = CGRect(x: 0, y: 0, width: view.frame.width - 70, height: 0)
         searchController.searchResultsUpdater = self
         searchController.searchBar.delegate = self

--- a/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/View/SearchResultViewController.swift
@@ -205,6 +205,12 @@ extension SearchResultViewController: UISearchResultsUpdating, UISearchBarDelega
     }
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        if !self.postTitle.isEmpty {
+            var snapshot = dataSource.snapshot()
+            snapshot.deleteAllItems()
+            snapshot.appendSections([.list])
+            dataSource.apply(snapshot)
+        }
         titlePublisher.send(self.postTitle)
         self.requestSegmentedControl.isHidden = false
         self.listTableView.isHidden = false

--- a/iOS/Village/Village/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
+++ b/iOS/Village/Village/Presentation/SearchResult/ViewModel/SearchResultViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 final class SearchResultViewModel {
     
     private var cancellableBag = Set<AnyCancellable>()
-    private var searchResultList = PassthroughSubject<[PostResponseDTO], NetworkError>()
+    private let searchResultList = PassthroughSubject<[PostResponseDTO], NetworkError>()
     private var postTitle: String = ""
     private var lastPostID: String = ""
     
@@ -95,13 +95,13 @@ final class SearchResultViewModel {
 extension SearchResultViewModel {
     
     struct Input {
-        var postTitle: AnyPublisher<String, Never>
-        var toggleSubject: AnyPublisher<Void, Never>
-        var scrollEvent: AnyPublisher<Void, Never>
+        let postTitle: AnyPublisher<String, Never>
+        let toggleSubject: AnyPublisher<Void, Never>
+        let scrollEvent: AnyPublisher<Void, Never>
     }
     
     struct Output {
-        var searchResultList: AnyPublisher<[PostResponseDTO], NetworkError>
+        let searchResultList: AnyPublisher<[PostResponseDTO], NetworkError>
     }
     
 }


### PR DESCRIPTION
## 이슈
- #516

## 체크리스트
- [x] 검색 결과 버그 수정

## 고민한 내용
### prepareForReuse
- 통신결과가 없을 경우 기존의 셀이 사라지지않고 남아있는 버그가 생겼다.
- prepareForReuse를 활용해서 남아있지 않게 변경했다.
- prepareForReuse에 대해서 별 생각이 없었는데 활용을 많은 부분에서 해야겠다.
### 검색시마다 데이터소스 초기화
- deleteAllItems를 이용해서 초기화
