### PR TITLE
[iOS/#531] 포스트뷰 때문에 채팅창 밀리는 버그 수정

### DIFF
--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -259,7 +259,7 @@ private extension ChatRoomViewController {
     func configureConstraints() {
         
         NSLayoutConstraint.activate([
-            keyboardStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            keyboardStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             keyboardStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             keyBoardStackViewBottomConstraint
         ])
@@ -267,11 +267,12 @@ private extension ChatRoomViewController {
 //        keyboardMoreButton.widthAnchor.constraint(equalToConstant: 40).isActive = true
         
         NSLayoutConstraint.activate([
-            keyboardTextField.heightAnchor.constraint(equalToConstant: 40),
-            keyboardTextField.leadingAnchor.constraint(equalTo: keyboardStackView.leadingAnchor, constant: 20)
+            keyboardTextField.heightAnchor.constraint(equalToConstant: 40)
         ])
         
-        keyboardSendButton.widthAnchor.constraint(equalToConstant: 40).isActive = true
+        NSLayoutConstraint.activate([
+            keyboardSendButton.widthAnchor.constraint(equalToConstant: 40)
+        ])
         
         NSLayoutConstraint.activate([
             chatTableView.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -259,8 +259,8 @@ private extension ChatRoomViewController {
     func configureConstraints() {
         
         NSLayoutConstraint.activate([
-            keyboardStackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            keyboardStackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            keyboardStackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 20),
+            keyboardStackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             keyBoardStackViewBottomConstraint
         ])
         
@@ -275,10 +275,10 @@ private extension ChatRoomViewController {
         ])
         
         NSLayoutConstraint.activate([
-            chatTableView.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),
+            chatTableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 80),
             chatTableView.bottomAnchor.constraint(equalTo: keyboardStackView.topAnchor),
-            chatTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            chatTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            chatTableView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            chatTableView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
     }
     
@@ -373,8 +373,8 @@ private extension ChatRoomViewController {
         if post.isRequest == true {
             view.addSubview(self.requestPostView)
             NSLayoutConstraint.activate([
-                requestPostView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                requestPostView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                requestPostView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                requestPostView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
                 requestPostView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
                 requestPostView.heightAnchor.constraint(equalToConstant: 80),
                 chatTableView.topAnchor.constraint(equalTo: requestPostView.bottomAnchor)
@@ -384,8 +384,8 @@ private extension ChatRoomViewController {
         } else {
             view.addSubview(self.rentPostView)
             NSLayoutConstraint.activate([
-                rentPostView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                rentPostView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                rentPostView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+                rentPostView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
                 rentPostView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
                 rentPostView.heightAnchor.constraint(equalToConstant: 80),
                 chatTableView.topAnchor.constraint(equalTo: rentPostView.bottomAnchor)
@@ -443,7 +443,7 @@ private extension ChatRoomViewController {
         keyBoardStackViewBottomConstraint = keyboardStackView
             .bottomAnchor
             .constraint(
-                equalTo: view.bottomAnchor,
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor,
                 constant: -keyboardFrame.height
             )
         keyBoardStackViewBottomConstraint.isActive = true

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -244,6 +244,7 @@ private extension ChatRoomViewController {
     
     func setUI() {
         view.addSubview(chatTableView)
+        self.chatTableView.isHidden = true
         
         keyboardTextField.delegate = self
         
@@ -273,6 +274,7 @@ private extension ChatRoomViewController {
         keyboardSendButton.widthAnchor.constraint(equalToConstant: 40).isActive = true
         
         NSLayoutConstraint.activate([
+            chatTableView.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),
             chatTableView.bottomAnchor.constraint(equalTo: keyboardStackView.topAnchor),
             chatTableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             chatTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
@@ -395,6 +397,7 @@ private extension ChatRoomViewController {
                 self.chatTableView.scrollToRow(
                     at: IndexPath(row: self.viewModel.getLog().count-1, section: 0), at: .bottom, animated: false
                 )
+                self.chatTableView.isHidden = false
             }
         }
     }


### PR DESCRIPTION
## 이슈
- #531 

## 체크리스트
- [x] 포스트뷰 때문에 채팅창 밀리는 버그 수정

## 고민한 내용
- constraints를 미리 80으로 잡아준 다음에, 포스트뷰가 생성될때 topAnchor를 다시 바꿔줌.
- 채팅창이 아래로 도착하기 전에 채팅창을 숨겨주고 도착했을 때, 채팅창을 나타나게해서 버벅임을 최소화함

## 스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-12-13 at 17 32 46](https://github.com/boostcampwm2023/iOS05-Village/assets/59719500/c9edc77a-a66c-4a38-8d82-90b3d61847c8)
