### PR TITLE
[iOS/#522] 이미지 상세화면 구현

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		44C1F5E62B0FE37C0047A436 /* PostDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C1F5E52B0FE37C0047A436 /* PostDetailViewModel.swift */; };
 		44C1F5ED2B0FE44A0047A436 /* UserResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C1F5EC2B0FE44A0047A436 /* UserResponseDTO.swift */; };
 		44C1F5F32B0FF63C0047A436 /* PostResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C1F5F22B0FF63C0047A436 /* PostResponseDTO.swift */; };
+		44FC33692B2986E900FF4D65 /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FC33682B2986E900FF4D65 /* ImageDetailView.swift */; };
 		59110EFB2B15F3D60009E9AC /* ChatRoomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110EFA2B15F3D60009E9AC /* ChatRoomTableViewCell.swift */; };
 		59110EFD2B15F5340009E9AC /* UITableViewCell+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110EFC2B15F5340009E9AC /* UITableViewCell+Identifier.swift */; };
 		59110F042B1725C20009E9AC /* NotificationName+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110F032B1725C20009E9AC /* NotificationName+.swift */; };
@@ -180,6 +181,7 @@
 		44C1F5E52B0FE37C0047A436 /* PostDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailViewModel.swift; sourceTree = "<group>"; };
 		44C1F5EC2B0FE44A0047A436 /* UserResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponseDTO.swift; sourceTree = "<group>"; };
 		44C1F5F22B0FF63C0047A436 /* PostResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostResponseDTO.swift; sourceTree = "<group>"; };
+		44FC33682B2986E900FF4D65 /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
 		59110EFA2B15F3D60009E9AC /* ChatRoomTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomTableViewCell.swift; sourceTree = "<group>"; };
 		59110EFC2B15F5340009E9AC /* UITableViewCell+Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Identifier.swift"; sourceTree = "<group>"; };
 		59110F022B1714BE0009E9AC /* Village.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Village.entitlements; sourceTree = "<group>"; };
@@ -401,6 +403,7 @@
 			isa = PBXGroup;
 			children = (
 				444A508F2B0C60F900454397 /* ImagePageView.swift */,
+				44FC33682B2986E900FF4D65 /* ImageDetailView.swift */,
 				444A50972B0CE25200454397 /* DurationView.swift */,
 				444A50992B0CE94E00454397 /* DateView.swift */,
 				446362C82B0DF9E800B74DA7 /* PriceLabel.swift */,
@@ -1218,6 +1221,7 @@
 				8F8F0B8B2B1D985A00BE97D2 /* BlockedUserViewController.swift in Sources */,
 				8F8F0B8D2B1DA91500BE97D2 /* HiddenRentPostTableViewCell.swift in Sources */,
 				59AADE382B22086400C3E17D /* EditProfileViewModel.swift in Sources */,
+				44FC33692B2986E900FF4D65 /* ImageDetailView.swift in Sources */,
 				8FBB65CC2B20587B00C6A133 /* BlockedUserTableViewCell.swift in Sources */,
 				59A384642B26093600660B70 /* ReportViewModel.swift in Sources */,
 				59A384662B260DB000660B70 /* ReportDTO.swift in Sources */,

--- a/iOS/Village/Village/Presentation/PostDetail/Custom/ImageDetailView.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/ImageDetailView.swift
@@ -46,7 +46,7 @@ final class ImageDetailView: UIView {
     
     @objc
     private func dismissAction() {
-        UIView.animate(withDuration: 0.1, animations: { [weak self] in
+        UIView.animate(withDuration: 0.2, animations: { [weak self] in
             self?.alpha = 0
         })
     }

--- a/iOS/Village/Village/Presentation/PostDetail/Custom/ImageDetailView.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/ImageDetailView.swift
@@ -1,0 +1,68 @@
+//
+//  ImageDetailView.swift
+//  Village
+//
+//  Created by 정상윤 on 12/13/23.
+//
+
+import UIKit
+
+final class ImageDetailView: UIView {
+    
+    private lazy var imageView: UIImageView = {
+        let view = UIImageView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.contentMode = .scaleAspectFit
+        view.backgroundColor = .systemBackground
+        
+        return view
+    }()
+    
+    private lazy var dismissButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: ImageSystemName.xmark.rawValue), for: .normal)
+        button.tintColor = .label
+        button.addTarget(self, action: #selector(dismissAction), for: .touchUpInside)
+        
+        return button
+    }()
+    
+    init(imageData: Data) {
+        super.init(frame: .zero)
+        imageView.image = UIImage(data: imageData)
+        
+        addSubview(imageView)
+        addSubview(dismissButton)
+        setLayoutConstraints()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    @objc
+    private func dismissAction() {
+        UIView.animate(withDuration: 0.5, animations: { [weak self] in
+            self?.alpha = 0
+        })
+        removeFromSuperview()
+    }
+    
+    private func setLayoutConstraints() {
+        NSLayoutConstraint.activate([
+            dismissButton.widthAnchor.constraint(equalToConstant: 30),
+            dismissButton.heightAnchor.constraint(equalToConstant: 30),
+            dismissButton.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
+            dismissButton.topAnchor.constraint(equalTo: topAnchor, constant: 5)
+        ])
+        
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+}

--- a/iOS/Village/Village/Presentation/PostDetail/Custom/ImageDetailView.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/ImageDetailView.swift
@@ -13,7 +13,7 @@ final class ImageDetailView: UIView {
         let view = UIImageView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentMode = .scaleAspectFit
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = .black
         
         return view
     }()
@@ -22,15 +22,14 @@ final class ImageDetailView: UIView {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setImage(UIImage(systemName: ImageSystemName.xmark.rawValue), for: .normal)
-        button.tintColor = .label
+        button.tintColor = .white
         button.addTarget(self, action: #selector(dismissAction), for: .touchUpInside)
         
         return button
     }()
     
-    init(imageData: Data) {
-        super.init(frame: .zero)
-        imageView.image = UIImage(data: imageData)
+    override init(frame: CGRect) {
+        super.init(frame: frame)
         
         addSubview(imageView)
         addSubview(dismissButton)
@@ -41,12 +40,15 @@ final class ImageDetailView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func setImage(data: Data) {
+        imageView.image = UIImage(data: data)
+    }
+    
     @objc
     private func dismissAction() {
-        UIView.animate(withDuration: 0.5, animations: { [weak self] in
+        UIView.animate(withDuration: 0.1, animations: { [weak self] in
             self?.alpha = 0
         })
-        removeFromSuperview()
     }
     
     private func setLayoutConstraints() {

--- a/iOS/Village/Village/Presentation/PostDetail/Custom/ImagePageView.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/ImagePageView.swift
@@ -6,8 +6,11 @@
 //
 
 import UIKit
+import Combine
 
 final class ImagePageView: UIView {
+    
+    var presentFullImage = PassthroughSubject<Data, Never>()
     
     private var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -82,25 +85,17 @@ final class ImagePageView: UIView {
         imageView.contentMode = .scaleAspectFit
         imageView.isUserInteractionEnabled = true
         imageView.addGestureRecognizer(UITapGestureRecognizer(target: self, 
-                                                              action: #selector(presentImageDetailView(sender:))))
+                                                              action: #selector(showFullImage(sender:))))
         
         return imageView
     }
     
     @objc
-    private func presentImageDetailView(sender: UITapGestureRecognizer) {
+    private func showFullImage(sender: UITapGestureRecognizer) {
         guard let imageView = sender.view as? UIImageView,
-              let data = imageView.image?.jpegData(compressionQuality: 1.0) else { return }
+              let data = imageView.image?.pngData() else { return }
         
-        let imageDetailView: ImageDetailView = {
-            let view = ImageDetailView(imageData: data)
-            view.translatesAutoresizingMaskIntoConstraints = false
-            view.alpha = 0
-            
-            return view
-        }()
-        addSubview(imageDetailView)
-        setFullLayoutConstraint(child: imageDetailView, parent: self)
+        presentFullImage.send(data)
     }
     
     private func configurePageControl(count: Int) {
@@ -115,7 +110,12 @@ final class ImagePageView: UIView {
             pageControl.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
         
-        setFullLayoutConstraint(child: imageStackView, parent: scrollView)
+        NSLayoutConstraint.activate([
+            imageStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            imageStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            imageStackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            imageStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor)
+        ])
     }
     
     private func setFullLayoutConstraint(child: UIView, parent: UIView) {

--- a/iOS/Village/Village/Presentation/PostDetail/Custom/ImagePageView.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/ImagePageView.swift
@@ -16,12 +16,14 @@ final class ImagePageView: UIView {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.isPagingEnabled = true
         scrollView.showsHorizontalScrollIndicator = false
+        
         return scrollView
     }()
     
     private var imageStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
+        
         return stackView
     }()
     
@@ -32,6 +34,7 @@ final class ImagePageView: UIView {
         pageControl.currentPageIndicatorTintColor = .primary500
         pageControl.pageIndicatorTintColor = .secondaryLabel
         pageControl.backgroundStyle = .minimal
+        
         return pageControl
     }()
     

--- a/iOS/Village/Village/Presentation/PostDetail/Custom/ImagePageView.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/Custom/ImagePageView.swift
@@ -99,23 +99,22 @@ final class ImagePageView: UIView {
     }
     
     private func setLayoutConstraints() {
-        NSLayoutConstraint.activate([
-            scrollView.topAnchor.constraint(equalTo: self.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
-        ])
+        setFullLayoutConstraint(child: scrollView, parent: self)
         
         NSLayoutConstraint.activate([
-            pageControl.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            pageControl.centerXAnchor.constraint(equalTo: self.centerXAnchor)
+            pageControl.bottomAnchor.constraint(equalTo: bottomAnchor),
+            pageControl.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
         
+        setFullLayoutConstraint(child: imageStackView, parent: scrollView)
+    }
+    
+    private func setFullLayoutConstraint(child: UIView, parent: UIView) {
         NSLayoutConstraint.activate([
-            imageStackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
-            imageStackView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
-            imageStackView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            imageStackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor)
+            child.topAnchor.constraint(equalTo: parent.topAnchor),
+            child.leadingAnchor.constraint(equalTo: parent.leadingAnchor),
+            child.trailingAnchor.constraint(equalTo: parent.trailingAnchor),
+            child.bottomAnchor.constraint(equalTo: parent.bottomAnchor)
         ])
     }
 

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -242,7 +242,6 @@ final class PostDetailViewController: UIViewController {
                                 startDate: post.startDate, 
                                 endDate: post.endDate,
                                 description: post.description)
-        imagePageView.setImageURL(post.images)
         priceLabel.setPrice(price: post.price)
     }
     
@@ -295,6 +294,7 @@ private extension PostDetailViewController {
         
         handlePost(output: output)
         handleUser(output: output)
+        handleImageData(output: output)
         handleRoomID(output: output)
         handleMore(output: output)
         handleModify(output: output)
@@ -341,7 +341,23 @@ private extension PostDetailViewController {
                 self?.chatButton.backgroundColor = .primary500
             }
             .store(in: &cancellableBag)
-    }    
+    }
+    
+    private func handleImageData(output: ViewModel.Output) {
+        output.imageData
+            .receive(on: DispatchQueue.main)
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    dump(error)
+                }
+            } receiveValue: { [weak self] imageData in
+                self?.imagePageView.setContent(imageData)
+            }
+            .store(in: &cancellableBag)
+    }
     
     private func handleRoomID(output: ViewModel.Output) {
         output.roomID.receive(on: DispatchQueue.main)

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -266,7 +266,7 @@ final class PostDetailViewController: UIViewController {
         imagePageView.presentFullImage
             .sink { [weak self] imageData in
                 self?.imageDetailView.setImage(data: imageData)
-                UIView.animate(withDuration: 0.1, animations: {
+                UIView.animate(withDuration: 0.2, animations: {
                     self?.imageDetailView.alpha = 1
                 })
             }

--- a/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/PostDetailViewController.swift
@@ -49,6 +49,14 @@ final class PostDetailViewController: UIViewController {
         return imagePageView
     }()
     
+    private lazy var imageDetailView: ImageDetailView = {
+        let view = ImageDetailView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.alpha = 0
+        
+        return view
+    }()
+    
     private lazy var postContentView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -180,6 +188,7 @@ final class PostDetailViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
         
         bindingViewModel()
+        bindImagePageView()
         configureUI()
         configureNavigationItem()
     }
@@ -252,6 +261,17 @@ final class PostDetailViewController: UIViewController {
             userInfoView.setContent(imageURL: nil, nickname: "(탈퇴한 회원)")
         }
     }
+    
+    private func bindImagePageView() {
+        imagePageView.presentFullImage
+            .sink { [weak self] imageData in
+                self?.imageDetailView.setImage(data: imageData)
+                UIView.animate(withDuration: 0.1, animations: {
+                    self?.imageDetailView.alpha = 1
+                })
+            }
+            .store(in: &cancellableBag)
+    }
 
 }
 
@@ -260,6 +280,7 @@ private extension PostDetailViewController {
     func configureUI() {
         view.addSubview(scrollView)
         view.addSubview(footerView)
+        view.addSubview(imageDetailView)
         scrollView.addSubview(scrollViewContainerView)
         scrollViewContainerView.addArrangedSubview(imagePageView)
         scrollViewContainerView.addArrangedSubview(postContentView)
@@ -468,6 +489,13 @@ private extension PostDetailViewController {
             footerView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             footerView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             footerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            imageDetailView.topAnchor.constraint(equalTo: view.topAnchor),
+            imageDetailView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            imageDetailView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            imageDetailView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
         
         chatButton.centerYAnchor.constraint(equalTo: footerView.centerYAnchor).isActive = true

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -83,10 +83,6 @@ final class PostDetailViewModel {
         )
     }
     
-}
-
-private extension PostDetailViewModel {
-    
     func getPost(id: Int) {
         let endpoint = APIEndPoints.getPost(id: id)
         
@@ -102,6 +98,10 @@ private extension PostDetailViewModel {
             }
         }
     }
+    
+}
+
+private extension PostDetailViewModel {
     
     func updatePost(id: Int) {
         let endpoint = APIEndPoints.getPost(id: id)

--- a/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
+++ b/iOS/Village/Village/Presentation/PostDetail/ViewModel/PostDetailViewModel.swift
@@ -15,6 +15,7 @@ final class PostDetailViewModel {
     
     private let post = PassthroughSubject<PostResponseDTO, NetworkError>()
     private let user = PassthroughSubject<UserResponseDTO, NetworkError>()
+    private let imageData = PassthroughSubject<[Data], NetworkError>()
     private let roomID = PassthroughSubject<PostRoomResponseDTO, NetworkError>()
     private let moreOutput = PassthroughSubject<String, Never>()
     private let modifyOutput = PassthroughSubject<PostResponseDTO, NetworkError>()
@@ -72,6 +73,7 @@ final class PostDetailViewModel {
         return Output(
             post: post.eraseToAnyPublisher(),
             user: user.eraseToAnyPublisher(),
+            imageData: imageData.eraseToAnyPublisher(),
             moreOutput: moreOutput.eraseToAnyPublisher(),
             roomID: roomID.eraseToAnyPublisher(),
             reportOutput: reportOutput.eraseToAnyPublisher(),
@@ -81,7 +83,10 @@ final class PostDetailViewModel {
         )
     }
     
-    // TODO: Private 해주세요
+}
+
+private extension PostDetailViewModel {
+    
     func getPost(id: Int) {
         let endpoint = APIEndPoints.getPost(id: id)
         
@@ -110,7 +115,7 @@ final class PostDetailViewModel {
         }
     }
     
-    private func getUser(id: String) {
+    func getUser(id: String) {
         let endpoint = APIEndPoints.getUser(id: id)
         
         Task {
@@ -123,7 +128,7 @@ final class PostDetailViewModel {
         }
     }
     
-    private func createChatRoom() {
+    func createChatRoom() {
         let request = PostRoomRequestDTO(writer: self.userID, postID: self.postID)
         let endpoint = APIEndPoints.postCreateChatRoom(with: request)
         Task {
@@ -137,7 +142,7 @@ final class PostDetailViewModel {
         }
     }
     
-    private func deletePost() {
+    func deletePost() {
         let endpoint = APIEndPoints.deletePost(with: self.postID)
         
         Task {
@@ -151,7 +156,7 @@ final class PostDetailViewModel {
         }
     }
     
-    private func hidePost() {
+    func hidePost() {
         let endpoint = APIEndPoints.hidePost(postID: self.postID)
         
         Task {
@@ -167,7 +172,7 @@ final class PostDetailViewModel {
         }
     }
     
-    private func blockUser() {
+    func blockUser() {
         let endpoint = APIEndPoints.blockUser(userID: self.userID)
         
         Task {
@@ -200,6 +205,7 @@ extension PostDetailViewModel {
     struct Output {
         let post: AnyPublisher<PostResponseDTO, NetworkError>
         let user: AnyPublisher<UserResponseDTO, NetworkError>
+        let imageData: AnyPublisher<[Data], NetworkError>
         let moreOutput: AnyPublisher<String, Never>
         let roomID: AnyPublisher<PostRoomResponseDTO, NetworkError>
         let reportOutput: AnyPublisher<(postID: Int, userID: String), Never>


### PR DESCRIPTION
## 이슈
- close #522 

## 체크리스트
- [x] ImageDetailView 커스텀 뷰 구현
- [x] PostDetailViewModel에서 이미지 데이터도 서버에서 받아서 넘겨주도록 수정
- [x] 이미지 탭 이벤트 Subject 바인딩 추가

## 고민한 내용
- 이미지를 탭했을 때 디테일 뷰가 화면 전체로 나타나도록 하기 위해서 뷰 컨트롤러에서 기능이 동작하도록 했습니다.
- 이를 위해 ImagePageView에 이미지가 탭 됐을 때 해당 이미지의 데이터와 탭이 됐으니 디테일뷰를 띄우라는 것을 뷰 컨트롤러에서 바인딩하여 처리하도록 구현했습니다.
- 네비게이션 바까지 채우도록 시도해봤지만, 잘 안돼서 추후 개선점으로 남겨두겠습니다.

## 스크린샷
![Simulator Screen Recording - iPhone 15 - 2023-12-13 at 19 21 21](https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/825019d8-81f4-42d6-9243-69aa3aa48fc2)

