### PR TITLE
[iOS/#541] PHPicker에서 특정 이미지 포멧 로드 안되는 문제 해결

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		44C1F5ED2B0FE44A0047A436 /* UserResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C1F5EC2B0FE44A0047A436 /* UserResponseDTO.swift */; };
 		44C1F5F32B0FF63C0047A436 /* PostResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C1F5F22B0FF63C0047A436 /* PostResponseDTO.swift */; };
 		44FC33692B2986E900FF4D65 /* ImageDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FC33682B2986E900FF4D65 /* ImageDetailView.swift */; };
+		44FC336B2B2A023C00FF4D65 /* NSItemProvider+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FC336A2B2A023C00FF4D65 /* NSItemProvider+.swift */; };
 		59110EFB2B15F3D60009E9AC /* ChatRoomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110EFA2B15F3D60009E9AC /* ChatRoomTableViewCell.swift */; };
 		59110EFD2B15F5340009E9AC /* UITableViewCell+Identifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110EFC2B15F5340009E9AC /* UITableViewCell+Identifier.swift */; };
 		59110F042B1725C20009E9AC /* NotificationName+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110F032B1725C20009E9AC /* NotificationName+.swift */; };
@@ -182,6 +183,7 @@
 		44C1F5EC2B0FE44A0047A436 /* UserResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserResponseDTO.swift; sourceTree = "<group>"; };
 		44C1F5F22B0FF63C0047A436 /* PostResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostResponseDTO.swift; sourceTree = "<group>"; };
 		44FC33682B2986E900FF4D65 /* ImageDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDetailView.swift; sourceTree = "<group>"; };
+		44FC336A2B2A023C00FF4D65 /* NSItemProvider+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSItemProvider+.swift"; sourceTree = "<group>"; };
 		59110EFA2B15F3D60009E9AC /* ChatRoomTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomTableViewCell.swift; sourceTree = "<group>"; };
 		59110EFC2B15F5340009E9AC /* UITableViewCell+Identifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+Identifier.swift"; sourceTree = "<group>"; };
 		59110F022B1714BE0009E9AC /* Village.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Village.entitlements; sourceTree = "<group>"; };
@@ -899,6 +901,7 @@
 		8FBE3B0E2B04CB8900660530 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				44FC336A2B2A023C00FF4D65 /* NSItemProvider+.swift */,
 				8FBE3B112B04CF6300660530 /* UILabel+SetTitle.swift */,
 				8FBE3B132B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift */,
 				59D4DBE12B068C6400BBA2D5 /* UIView+Layer.swift */,
@@ -1159,6 +1162,7 @@
 				59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */,
 				596AD1F22B259147005860B3 /* BlockedUsersViewModel.swift in Sources */,
 				59E2C1662B24B6D9004428F7 /* RequestFilterDTO.swift in Sources */,
+				44FC336B2B2A023C00FF4D65 /* NSItemProvider+.swift in Sources */,
 				8F1E2CEE2B1F163D00179E34 /* GetRoomResponseDTO.swift in Sources */,
 				59E6A20F2B205C8500A2DF21 /* RequestPostSummaryView.swift in Sources */,
 				446B61002B2433E100A361CB /* ImageItem.swift in Sources */,

--- a/iOS/Village/Village/Presentation/EditProfile/View/EditProfileViewController.swift
+++ b/iOS/Village/Village/Presentation/EditProfile/View/EditProfileViewController.swift
@@ -171,15 +171,15 @@ extension EditProfileViewController: PHPickerViewControllerDelegate {
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.dismiss(animated: true, completion: nil)
         guard let result = results.first else { return }
-        result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] (image, _) in
-            guard let image = image as? UIImage else { return }
-            let scaleImage = image.resize(newWidth: 100, newHeight: 100)
-            DispatchQueue.main.async {
-                self?.profileImageView.setProfile(image: scaleImage)
+        result.itemProvider.getImageData(completion: { imageData in
+            guard let data = imageData,
+                  let image = UIImage(data: data)?.resize(newWidth: 100, newHeight: 100) else { return }
+            
+            DispatchQueue.main.async { [weak self] in
+                self?.profileImageView.setProfile(image: image)
+                self?.profileImageDataSubject.send(image.pngData())
             }
-            let data = scaleImage.pngData()
-            self?.profileImageDataSubject.send(data)
-        }
+        })
     }
     
 }

--- a/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
+++ b/iOS/Village/Village/Presentation/PostCreate/View/PostCreateViewController.swift
@@ -243,6 +243,9 @@ final class PostCreateViewController: UIViewController {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] imageItemList in
                 guard let self = self else { return }
+                if !imageItemList.isEmpty {
+                    imageWarn(enable: false)
+                }
                 self.imageUploadView.setImageItem(items: imageItemList)
             }
             .store(in: &cancellableBag)
@@ -454,13 +457,10 @@ extension PostCreateViewController: PHPickerViewControllerDelegate {
         var imageData = [Data]()
         itemProviders.forEach { itemProvider in
             dispatchGroup.enter()
-            itemProvider.loadObject(ofClass: UIImage.self) { uiimage, _ in
-                guard let image = uiimage as? UIImage,
-                      let jpegData = image.jpegData(compressionQuality: 0.1) else { return }
-                DispatchQueue.main.async {
-                    self.imageWarn(enable: false)
+            itemProvider.getImageData { data in
+                if let data {
+                    imageData.append(data)
                 }
-                imageData.append(jpegData)
                 dispatchGroup.leave()
             }
         }

--- a/iOS/Village/Village/Presentation/Utils/Extensions/NSItemProvider+.swift
+++ b/iOS/Village/Village/Presentation/Utils/Extensions/NSItemProvider+.swift
@@ -1,0 +1,54 @@
+//
+//  NSItemProvider+.swift
+//  Village
+//
+//  Created by 정상윤 on 12/14/23.
+//
+
+import PhotosUI
+
+extension NSItemProvider {
+    
+    func getImageData(completion: @escaping (Data?) -> Void) {
+        let imageTypeIdentifiers = [
+            UTType.webP.identifier,
+            UTType.heic.identifier,
+            UTType.rawImage.identifier
+        ]
+        
+        if canLoadObject(ofClass: UIImage.self) {
+            loadObject(ofClass: UIImage.self) { uiimage, _ in
+                guard let image = uiimage as? UIImage,
+                      let jpegData = image.jpegData(compressionQuality: 0.1) else { return }
+                completion(jpegData)
+            }
+        } else {
+            for identifier in imageTypeIdentifiers {
+                loadFileRepresentation(forTypeIdentifier: identifier) { [weak self] url, _ in
+                    if let fileURL = url,
+                       let fileData = try? Data(contentsOf: fileURL),
+                       let compressedData = UIImage(data: fileData)?.jpegData(compressionQuality: 0.1) {
+                        self?.deleteFile(url: fileURL)
+                        completion(compressedData)
+                    }
+                }
+            }
+        }
+    }
+    
+}
+
+fileprivate extension NSItemProvider {
+    
+    func deleteFile(url: URL) {
+        let fileManager = FileManager.default
+        
+        do {
+            try fileManager.removeItem(at: url)
+        } catch {
+            dump("File deletion failed: \(error)")
+        }
+        
+    }
+    
+}


### PR DESCRIPTION
## 이슈
- #541 

## 체크리스트
- [x] NSItemProvider extension 구현
- [x] temp 파일 삭제 구현

## 고민한 내용
- 현재 저희 최소 지원 iOS가 15이기 때문에 loadDataRepresentation을 사용할 수 없었기 때문에 loadFileRepresentation을 사용해야 했습니다.
- loadObject를 또 다른 함수로 wrapping했기 때문에 비동기 이슈가 있었고, escaping completion을 통해 해결했습니다.
- 주의해야했던 점은 loadFileRepresentation은 기기 임시 폴더에 파일을 복사하여 데이터를 가져오는 방식이고, 임시 파일이 그대로 남아있게 됩니다. 그래서 fileprivate 함수로 파일을 삭제하는 로직을 추가로 구현했습니다.
- 우선 현재는 webp, heic, rawImage 포멧을 불러올 수 있도록 했습니다. 추후 다른 이미지 포멧 이슈가 생기면 추가하겠습니다.

## 스크린샷
- 이미지 파일 저장 캡쳐
<img width="755" alt="스크린샷 2023-12-14 오후 12 15 51" src="https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/aca58f55-5fd0-4d20-9331-d5e202270c5b">

- 삭제 동작 확인
![ezgif-4-dd3f094d64](https://github.com/boostcampwm2023/iOS05-Village/assets/19406851/3e735cea-098d-47fe-b2e6-f51c2235765e)
