### PR TITLE
[iOS/#557] Refresh Token 만료 처리 수정

### DIFF
--- a/iOS/Village/Village/Application/SceneDelegate.swift
+++ b/iOS/Village/Village/Application/SceneDelegate.swift
@@ -17,7 +17,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         addObservers()
         
         window = UIWindow(windowScene: windowScene)
-        autoLogin()
         window?.makeKeyAndVisible()
     }
     
@@ -41,31 +40,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                                                object: nil)
     }
     
-    private func autoLogin() {
-        guard let accessToken = JWTManager.shared.get()?.accessToken else {
-            window?.rootViewController = LoginViewController()
-            return
-        }
-        let endpoint = APIEndPoints.tokenExpire(accessToken: accessToken)
-        Task {
-            do {
-                try await APIProvider.shared.request(with: endpoint)
-                
-                window?.rootViewController = AppTabBarController()
-            } catch {
-                window?.rootViewController = LoginViewController()
-            }
-        }
-    }
-    
     @objc
     private func rootViewControllerToTabBarController() {
-        window?.rootViewController = AppTabBarController()
+        DispatchQueue.main.async { [weak self] in
+            self?.window?.rootViewController = AppTabBarController()
+        }
     }
     
     @objc
     private func rootViewControllerToLoginViewController() {
-        window?.rootViewController = LoginViewController()
+        DispatchQueue.main.async { [weak self] in
+            self?.window?.rootViewController = LoginViewController()
+        }
     }
 
 }

--- a/iOS/Village/Village/Network/APIProvider/AuthInterceptor.swift
+++ b/iOS/Village/Village/Network/APIProvider/AuthInterceptor.swift
@@ -47,9 +47,7 @@ struct AuthInterceptor: Interceptor {
                 try await refreshToken()
                 return .retry
             } catch let error {
-                DispatchQueue.main.async {
-                    NotificationCenter.default.post(name: .shouldLogin, object: nil)
-                }
+                NotificationCenter.default.post(name: .shouldLogin, object: nil)
                 return .doNotRetryWithError(error)
             }
         default:

--- a/iOS/Village/Village/Network/NetworkError.swift
+++ b/iOS/Village/Village/Network/NetworkError.swift
@@ -16,26 +16,29 @@ enum NetworkError: Error {
     case serverError(ServerError)
     case emptyData
     case parsingError
+    case refreshTokenExpired
     case decodingError(Error)
     
     var errorDescription: String {
         switch self {
         case .unknownError:
-            return "Unknown Error."
+            "Unknown Error."
         case .queryParameterError:
-            return "Query Parameter toDictionary Failed"
+            "Query Parameter toDictionary Failed"
         case .componentsError:
-            return "URL Components Error."
+            "URL Components Error."
         case .urlRequestError:
-            return "URL Request Error."
+            "URL Request Error."
         case .serverError(let serverError):
-            return "Server Error: \(serverError)."
+            "Server Error: \(serverError)."
         case .emptyData:
-            return "Empty Data."
+            "Empty Data."
         case .parsingError:
-            return "Parsing Error."
+            "Parsing Error."
         case .decodingError(let error):
-            return "Decoding Error: \(error)."
+            "Decoding Error: \(error)."
+        case .refreshTokenExpired:
+            "Refresh Token Expired. Login again."
         }
     }
     

--- a/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
+++ b/iOS/Village/Village/Presentation/MyPage/View/MyPageViewController.swift
@@ -332,7 +332,6 @@ private extension MyPageViewController {
     
     func handleLogout(output: ViewModel.Output) {
         output.logoutSucceed
-            .receive(on: DispatchQueue.main)
             .sink { completion in
                 switch completion {
                 case .finished:
@@ -348,7 +347,6 @@ private extension MyPageViewController {
     
     func handleDeleteAccount(output: ViewModel.Output) {
         output.deleteAccountSucceed
-            .receive(on: DispatchQueue.main)
             .sink { completion in
                 switch completion {
                 case .finished:


### PR DESCRIPTION
## 이슈
- #557 

## 체크리스트
- [x] AuthInterceptor refreshToken 함수 동작 수정
- [x] rootViewController 메인 스레드에서 변경 

## 고민한 내용
- 서버에서 refreshToken과 accessToken의 만료 모두 401 에러로 보내주기 때문에 만료 요청에서도 계속 401 처리로 빠지는 현상을 발견했습니다.
- 토큰 갱신 호출은 별개로 한번만 통신이 이뤄지도록 로직을 변경했습니다.
- AppDelegate에서 앱이 실행될 때 무조건 한번은 FCM 토큰을 서버에 보내기 때문에 SceneDelegate에서 따로 자동 로그인을 시도하지 않도록 변경했습니다.

## 스크린샷
없음