### PR TITLE
[BE/#577] 게시글 필터링 수정 및 레파지토리 분리

### DIFF
--- a/BE/src/config/mysql.config.ts
+++ b/BE/src/config/mysql.config.ts
@@ -6,9 +6,9 @@ import { PostEntity } from '../entities/post.entity';
 import { BlockUserEntity } from '../entities/blockUser.entity';
 import { PostImageEntity } from '../entities/postImage.entity';
 import { BlockPostEntity } from '../entities/blockPost.entity';
-import { ChatRoomEntity } from 'src/entities/chatRoom.entity';
+import { ChatRoomEntity } from '../entities/chatRoom.entity';
 import { RegistrationTokenEntity } from '../entities/registrationToken.entity';
-import { ChatEntity } from 'src/entities/chat.entity';
+import { ChatEntity } from '../entities/chat.entity';
 import { ReportEntity } from '../entities/report.entity';
 
 @Injectable()

--- a/BE/src/entities/blockUser.entity.ts
+++ b/BE/src/entities/blockUser.entity.ts
@@ -6,6 +6,7 @@ import {
   DeleteDateColumn,
 } from 'typeorm';
 import { UserEntity } from './user.entity';
+import { PostEntity } from './post.entity';
 
 @Entity('block_user')
 export class BlockUserEntity {
@@ -25,4 +26,8 @@ export class BlockUserEntity {
   @ManyToOne(() => UserEntity, (blocked) => blocked.user_hash)
   @JoinColumn({ name: 'blocked_user', referencedColumnName: 'user_hash' })
   blockedUser: UserEntity;
+
+  @ManyToOne(() => PostEntity, (blocked) => blocked.user_hash)
+  @JoinColumn({ name: 'blocked_user', referencedColumnName: 'user_hash' })
+  blockedUserPost: PostEntity;
 }

--- a/BE/src/entities/post.entity.ts
+++ b/BE/src/entities/post.entity.ts
@@ -13,6 +13,7 @@ import { UserEntity } from './user.entity';
 import { PostImageEntity } from './postImage.entity';
 import { BlockPostEntity } from './blockPost.entity';
 import { ReportEntity } from './report.entity';
+import { BlockUserEntity } from './blockUser.entity';
 
 @Entity('post')
 export class PostEntity {
@@ -65,6 +66,9 @@ export class PostEntity {
   @OneToMany(() => PostImageEntity, (post_image) => post_image.post)
   post_images: PostImageEntity[];
 
-  @OneToMany(() => BlockPostEntity, (post_image) => post_image.blocked_post)
+  @OneToMany(() => BlockPostEntity, (block_post) => block_post.blockedPost)
   blocked_posts: BlockPostEntity[];
+
+  @OneToMany(() => BlockUserEntity, (block_user) => block_user.blockedUserPost)
+  blocked_users: BlockUserEntity[];
 }

--- a/BE/src/entities/post.entity.ts
+++ b/BE/src/entities/post.entity.ts
@@ -63,10 +63,14 @@ export class PostEntity {
   @Column({ length: 2048, nullable: true, charset: 'utf8' })
   thumbnail: string;
 
-  @OneToMany(() => PostImageEntity, (post_image) => post_image.post)
+  @OneToMany(() => PostImageEntity, (post_image) => post_image.post, {
+    cascade: ['soft-remove'],
+  })
   post_images: PostImageEntity[];
 
-  @OneToMany(() => BlockPostEntity, (block_post) => block_post.blockedPost)
+  @OneToMany(() => BlockPostEntity, (block_post) => block_post.blockedPost, {
+    cascade: ['soft-remove'],
+  })
   blocked_posts: BlockPostEntity[];
 
   @OneToMany(() => BlockUserEntity, (block_user) => block_user.blockedUserPost)

--- a/BE/src/post/post.module.ts
+++ b/BE/src/post/post.module.ts
@@ -8,6 +8,7 @@ import { PostImageEntity } from '../entities/postImage.entity';
 import { BlockUserEntity } from '../entities/blockUser.entity';
 import { BlockPostEntity } from '../entities/blockPost.entity';
 import { AuthGuard } from 'src/common/guard/auth.guard';
+import { PostRepository } from './post.repository';
 
 @Module({
   imports: [
@@ -19,6 +20,6 @@ import { AuthGuard } from 'src/common/guard/auth.guard';
     ]),
   ],
   controllers: [PostController],
-  providers: [PostService, S3Handler, AuthGuard],
+  providers: [PostService, S3Handler, AuthGuard, PostRepository],
 })
 export class PostModule {}

--- a/BE/src/post/post.repository.spec.ts
+++ b/BE/src/post/post.repository.spec.ts
@@ -1,0 +1,56 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostRepository } from './post.repository';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { PostEntity } from '../entities/post.entity';
+import { DataSource } from 'typeorm';
+
+const mockDataSource = {
+  createEntityManager: jest.fn(),
+};
+describe('', () => {
+  let repository: PostRepository;
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostRepository,
+        { provide: DataSource, useValue: mockDataSource },
+        { provide: getRepositoryToken(PostEntity), useValue: {} },
+      ],
+    }).compile();
+    repository = module.get<PostRepository>(PostRepository);
+  });
+
+  it('should be defined', () => {
+    expect(repository).toBeDefined();
+  });
+
+  describe('createPost()', () => {
+    it('should success (nothing)', async function () {
+      const res = repository.createOption({
+        page: undefined,
+        requestFilter: undefined,
+        writer: undefined,
+        searchKeyword: undefined,
+      });
+      expect(res).toBe('post.id > -1');
+    });
+    it('should success (page)', async function () {
+      const res = repository.createOption({
+        page: 1,
+        requestFilter: undefined,
+        writer: undefined,
+        searchKeyword: undefined,
+      });
+      expect(res).toBe('post.id < 1');
+    });
+    it('should success (more than two options)', async function () {
+      const res = repository.createOption({
+        page: 1,
+        requestFilter: undefined,
+        writer: 'user',
+        searchKeyword: undefined,
+      });
+      expect(res).toBe("post.id < 1 AND post.user_hash = 'user'");
+    });
+  });
+});

--- a/BE/src/post/post.repository.ts
+++ b/BE/src/post/post.repository.ts
@@ -53,6 +53,14 @@ export class PostRepository extends Repository<PostEntity> {
       .getOne();
   }
 
+  async softDeleteCascade(postId: number) {
+    const post = await this.findOne({
+      where: { id: postId },
+      relations: ['blocked_posts', 'post_images'],
+    });
+    await this.softRemove(post);
+  }
+
   createOption(options: PostListDto) {
     let option =
       options.page === undefined

--- a/BE/src/post/post.repository.ts
+++ b/BE/src/post/post.repository.ts
@@ -35,6 +35,24 @@ export class PostRepository extends Repository<PostEntity> {
       .getMany();
   }
 
+  async findOneWithBlock(blocker: string, postId: number) {
+    return await this.createQueryBuilder('post')
+      .leftJoinAndSelect(
+        'post.blocked_posts',
+        'bp',
+        'bp.blocker = :blocker AND bp.blocked_post = post.id',
+        { blocker: blocker },
+      )
+      .leftJoinAndSelect(
+        'post.blocked_users',
+        'bu',
+        'bu.blocker = :blocker AND bu.blocked_user = post.user_hash',
+      )
+      .leftJoinAndSelect('post.post_images', 'pi', 'pi.post_id = post.id')
+      .where('post.id = :postId', { postId: postId })
+      .getOne();
+  }
+
   createOption(options: PostListDto) {
     let option =
       options.page === undefined

--- a/BE/src/post/post.repository.ts
+++ b/BE/src/post/post.repository.ts
@@ -54,11 +54,13 @@ export class PostRepository extends Repository<PostEntity> {
   }
 
   async softDeleteCascade(postId: number) {
-    const post = await this.findOne({
-      where: { id: postId },
-      relations: ['blocked_posts', 'post_images'],
+    await this.dataSource.transaction(async (manager) => {
+      const post = await manager.findOne(PostEntity, {
+        where: { id: postId },
+        relations: ['blocked_posts', 'post_images'],
+      });
+      await manager.softRemove(post);
     });
-    await this.softRemove(post);
   }
 
   createOption(options: PostListDto) {

--- a/BE/src/post/post.repository.ts
+++ b/BE/src/post/post.repository.ts
@@ -1,0 +1,54 @@
+import { DataSource, Repository } from 'typeorm';
+import { PostEntity } from '../entities/post.entity';
+import { Injectable } from '@nestjs/common';
+import { PostListDto } from './dto/postList.dto';
+
+@Injectable()
+export class PostRepository extends Repository<PostEntity> {
+  constructor(private dataSource: DataSource) {
+    super(PostEntity, dataSource.createEntityManager());
+  }
+
+  async findExceptBlock(
+    blocker: string,
+    options: PostListDto,
+  ): Promise<Array<PostEntity>> {
+    const limit = 20;
+    return await this.createQueryBuilder('post')
+      .leftJoin(
+        'post.blocked_posts',
+        'bp',
+        'bp.blocker = :blocker AND bp.blocked_post = post.id',
+        { blocker: blocker },
+      )
+      .leftJoin(
+        'post.blocked_users',
+        'bu',
+        'bu.blocker = :blocker AND bu.blocked_user = post.user_hash',
+      )
+      .leftJoinAndSelect('post.post_images', 'pi', 'pi.post_id = post.id')
+      .where('bp.blocked_post IS NULL')
+      .andWhere('bu.blocked_user IS NULL')
+      .andWhere(this.createOption(options))
+      .orderBy('post.id', 'DESC')
+      .limit(limit)
+      .getMany();
+  }
+
+  createOption(options: PostListDto) {
+    let option =
+      options.page === undefined
+        ? 'post.id > -1 AND '
+        : `post.id < ${options.page} AND `;
+    if (options.requestFilter !== undefined) {
+      option += `post.is_request = ${options.requestFilter} AND `;
+    }
+    if (options.writer !== undefined) {
+      option += `post.user_hash = '${options.writer}' AND `;
+    }
+    if (options.searchKeyword !== undefined) {
+      option += `post.title LIKE '%${options.searchKeyword}%' AND `;
+    }
+    return option.replace(/\s*AND\s*$/, '').trim();
+  }
+}

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -1,22 +1,14 @@
 import { HttpException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PostEntity } from '../entities/post.entity';
-import { LessThan, Like, Repository } from 'typeorm';
+import { Like, Repository } from 'typeorm';
 import { UpdatePostDto } from './dto/postUpdate.dto';
 import { PostImageEntity } from 'src/entities/postImage.entity';
 import { S3Handler } from '../common/S3Handler';
 import { PostListDto } from './dto/postList.dto';
-import { BlockUserEntity } from '../entities/blockUser.entity';
 import { BlockPostEntity } from '../entities/blockPost.entity';
-import { FindOperator } from 'typeorm/find-options/FindOperator';
 import { PostRepository } from './post.repository';
 
-interface WhereOption {
-  id: FindOperator<number>;
-  is_request?: boolean;
-  user_hash?: string;
-  title?: FindOperator<string>;
-}
 @Injectable()
 export class PostService {
   constructor(
@@ -24,8 +16,6 @@ export class PostService {
     private postRepository: Repository<PostEntity>,
     @InjectRepository(PostImageEntity)
     private postImageRepository: Repository<PostImageEntity>,
-    @InjectRepository(BlockUserEntity)
-    private blockUserRepository: Repository<BlockUserEntity>,
     @InjectRepository(BlockPostEntity)
     private blockPostRepository: Repository<BlockPostEntity>,
     private s3Handler: S3Handler,


### PR DESCRIPTION
## 이슈
- #577

## 체크리스트
- [x] 게시글 필터링 작업을 db에서 실행하도록 수정
- [x] post repository를 커스텀 레파지토리로 분리
- [x] 게시글 삭제에서 cascade 적용
- [x] 게시글 삭제에 트랜잭션 적용  

## 고민한 내용
- 기존에는 필터링을 게시글 목록 20개를 가져와서 필터링 하여 응답하는 방식이어서 차단된 게시글이 있다면 응답시 20개가 전부 안채워지는 문제가 있어 db에서 select 해 올떄 차단된 게시글을 필터링하여 20개 가져오도록 수정
- 게시글이 삭제될 때 연관된 테이블의 데이터를 cascade로 삭제되게 수정했다. 그래서 다른 레파지토리를 post service에서 의존하지 않게되었다.
- 게시글이 삭제될 때 연관된 모든 데이터가 같이 삭제 되어야 하기에 트랜잭션을 적용하여 원자성을 지키도록 수정 했다.

## 스크린샷
