### PR TITLE
[BE/#580] 트랜잭션 방법 변경

### DIFF
--- a/BE/src/common/base.repository.ts
+++ b/BE/src/common/base.repository.ts
@@ -1,0 +1,15 @@
+import { DataSource, EntityManager, Repository } from 'typeorm';
+import { ENTITY_MANAGER_KEY } from './interceptor/transaction.interceptor';
+
+export class BaseRepository {
+  constructor(
+    private dataSource: DataSource,
+    private request: Request,
+  ) {}
+
+  getRepository<T>(entityCls: new () => T): Repository<T> {
+    const entityManager: EntityManager =
+      this.request[ENTITY_MANAGER_KEY] ?? this.dataSource.manager;
+    return entityManager.getRepository(entityCls);
+  }
+}

--- a/BE/src/common/interceptor/transaction.interceptor.ts
+++ b/BE/src/common/interceptor/transaction.interceptor.ts
@@ -1,0 +1,42 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { concatMap, finalize, Observable } from 'rxjs';
+import { Request } from 'express';
+import { DataSource } from 'typeorm';
+import { catchError } from 'rxjs/operators';
+
+export const ENTITY_MANAGER_KEY = 'ENTITY_MANAGER';
+
+@Injectable()
+export class TransactionInterceptor implements NestInterceptor {
+  constructor(private dataSource: DataSource) {}
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>,
+  ): Promise<Observable<any>> {
+    const req = context.switchToHttp().getRequest<Request>();
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    req[ENTITY_MANAGER_KEY] = queryRunner.manager;
+
+    return next.handle().pipe(
+      concatMap(async (data) => {
+        await queryRunner.commitTransaction();
+        return data;
+      }),
+      catchError(async (e) => {
+        await queryRunner.rollbackTransaction();
+        throw e;
+      }),
+      finalize(async () => {
+        await queryRunner.release();
+      }),
+    );
+  }
+}

--- a/BE/src/post/post.controller.ts
+++ b/BE/src/post/post.controller.ts
@@ -23,6 +23,7 @@ import { PostListDto } from './dto/postList.dto';
 import { AuthGuard } from 'src/common/guard/auth.guard';
 import { UserHash } from 'src/common/decorator/auth.decorator';
 import { FilesSizeValidator } from '../common/files.validator';
+import { TransactionInterceptor } from '../common/interceptor/transaction.interceptor';
 
 @Controller('posts')
 @ApiTags('posts')
@@ -94,6 +95,7 @@ export class PostController {
   }
 
   @Delete('/:id')
+  @UseInterceptors(TransactionInterceptor)
   async postRemove(@Param('id') id: number, @UserHash() userId) {
     await this.postService.removePost(id, userId);
   }

--- a/BE/src/post/post.repository.spec.ts
+++ b/BE/src/post/post.repository.spec.ts
@@ -1,20 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PostRepository } from './post.repository';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { PostEntity } from '../entities/post.entity';
 import { DataSource } from 'typeorm';
 import { REQUEST } from '@nestjs/core';
 import { Request } from 'express';
 
-const mockDataSource = {
-  createEntityManager: jest.fn(),
-};
-// Mock Request 객체 생성
 const createMockRequest = (overrides: Partial<Request> = {}): Request => {
   return { ...overrides } as Request;
 };
 
-// 사용 예제
+const mockDataSource = {
+  createEntityManager: jest.fn(),
+};
+
 const mockRequest = createMockRequest({
   method: 'POST',
   url: '/api',

--- a/BE/src/post/post.repository.spec.ts
+++ b/BE/src/post/post.repository.spec.ts
@@ -3,10 +3,24 @@ import { PostRepository } from './post.repository';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { PostEntity } from '../entities/post.entity';
 import { DataSource } from 'typeorm';
+import { REQUEST } from '@nestjs/core';
+import { Request } from 'express';
 
 const mockDataSource = {
   createEntityManager: jest.fn(),
 };
+// Mock Request 객체 생성
+const createMockRequest = (overrides: Partial<Request> = {}): Request => {
+  return { ...overrides } as Request;
+};
+
+// 사용 예제
+const mockRequest = createMockRequest({
+  method: 'POST',
+  url: '/api',
+  headers: { 'Content-Type': 'application/json' },
+});
+
 describe('', () => {
   let repository: PostRepository;
   beforeEach(async () => {
@@ -14,10 +28,10 @@ describe('', () => {
       providers: [
         PostRepository,
         { provide: DataSource, useValue: mockDataSource },
-        { provide: getRepositoryToken(PostEntity), useValue: {} },
+        { provide: REQUEST, useValue: mockRequest },
       ],
     }).compile();
-    repository = module.get<PostRepository>(PostRepository);
+    repository = await module.resolve<PostRepository>(PostRepository);
   });
 
   it('should be defined', () => {

--- a/BE/src/post/post.repository.ts
+++ b/BE/src/post/post.repository.ts
@@ -1,4 +1,4 @@
-import { DataSource, Repository } from 'typeorm';
+import { DataSource } from 'typeorm';
 import { PostEntity } from '../entities/post.entity';
 import { Inject, Injectable, Scope } from '@nestjs/common';
 import { PostListDto } from './dto/postList.dto';

--- a/BE/src/post/post.repository.ts
+++ b/BE/src/post/post.repository.ts
@@ -1,12 +1,14 @@
 import { DataSource, Repository } from 'typeorm';
 import { PostEntity } from '../entities/post.entity';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, Scope } from '@nestjs/common';
 import { PostListDto } from './dto/postList.dto';
+import { BaseRepository } from '../common/base.repository';
+import { REQUEST } from '@nestjs/core';
 
-@Injectable()
-export class PostRepository extends Repository<PostEntity> {
-  constructor(private dataSource: DataSource) {
-    super(PostEntity, dataSource.createEntityManager());
+@Injectable({ scope: Scope.REQUEST })
+export class PostRepository extends BaseRepository {
+  constructor(dataSource: DataSource, @Inject(REQUEST) req: Request) {
+    super(dataSource, req);
   }
 
   async findExceptBlock(
@@ -14,7 +16,8 @@ export class PostRepository extends Repository<PostEntity> {
     options: PostListDto,
   ): Promise<Array<PostEntity>> {
     const limit = 20;
-    return await this.createQueryBuilder('post')
+    return await this.getRepository(PostEntity)
+      .createQueryBuilder('post')
       .leftJoin(
         'post.blocked_posts',
         'bp',
@@ -36,7 +39,8 @@ export class PostRepository extends Repository<PostEntity> {
   }
 
   async findOneWithBlock(blocker: string, postId: number) {
-    return await this.createQueryBuilder('post')
+    return await this.getRepository(PostEntity)
+      .createQueryBuilder('post')
       .leftJoinAndSelect(
         'post.blocked_posts',
         'bp',
@@ -54,13 +58,11 @@ export class PostRepository extends Repository<PostEntity> {
   }
 
   async softDeleteCascade(postId: number) {
-    await this.dataSource.transaction(async (manager) => {
-      const post = await manager.findOne(PostEntity, {
-        where: { id: postId },
-        relations: ['blocked_posts', 'post_images'],
-      });
-      await manager.softRemove(post);
+    const post = await this.getRepository(PostEntity).findOne({
+      where: { id: postId },
+      relations: ['blocked_posts', 'post_images'],
     });
+    await this.getRepository(PostEntity).softRemove(post);
   }
 
   createOption(options: PostListDto) {

--- a/BE/src/post/post.service.ts
+++ b/BE/src/post/post.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, Inject, Injectable } from '@nestjs/common';
+import { HttpException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PostEntity } from '../entities/post.entity';
 import { Like, Repository } from 'typeorm';
@@ -7,9 +7,6 @@ import { PostImageEntity } from 'src/entities/postImage.entity';
 import { S3Handler } from '../common/S3Handler';
 import { PostListDto } from './dto/postList.dto';
 import { PostRepository } from './post.repository';
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
-import { uuid } from 'uuidv4';
-import { promises as fsPromises } from 'fs';
 
 @Injectable()
 export class PostService {


### PR DESCRIPTION
## 이슈
- #580

## 체크리스트
- [x] transaction interceptor 생성
- [x] base repository 생성
- [x] post repository 생성

## 고민한 내용
- 여러 서비스를 사용 할 때 db 테이블이 연관되어 있는 작업을 한다면 사용하는 서비스들에 트랜잭션을 적용해야한다. 분리된 repository들에서 트랜잭션을 적용하기위해 base repository와 transaction interceptor 를 생성했다.
- 이렇게 구현 함으로써 이제 트랜잭션이 필요한 controller 에 transaction interceptor를 하는 것 만으로 간단하게 트랜잭션을 적용할 수 있게 되었다.
## 스크린샷
