### PR TITLE
[BE/#579]이미지 서비스 분리

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -36,7 +36,7 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
         "typeorm": "^0.3.17",
-        "uuidv4": "^6.2.13",
+        "uuid": "^9.0.1",
         "winston": "^3.11.0",
         "winston-daily-rotate-file": "^4.7.1",
         "ws": "^8.14.2"
@@ -2694,6 +2694,14 @@
         "reflect-metadata": "^0.1.13"
       }
     },
+    "node_modules/@nestjs/config/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@nestjs/core": {
       "version": "10.2.8",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.2.8.tgz",
@@ -2918,18 +2926,6 @@
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.0"
-      }
-    },
-    "node_modules/@nestjs/typeorm/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@nestjs/websockets": {
@@ -4125,11 +4121,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/validator": {
       "version": "13.11.7",
@@ -12496,26 +12487,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/uuidv4": {
-      "version": "6.2.13",
-      "resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.2.13.tgz",
-      "integrity": "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ==",
-      "dependencies": {
-        "@types/uuid": "8.3.4",
-        "uuid": "8.3.2"
-      }
-    },
-    "node_modules/uuidv4/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/BE/package.json
+++ b/BE/package.json
@@ -47,7 +47,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.17",
-    "uuidv4": "^6.2.13",
+    "uuid": "^9.0.1",
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1",
     "ws": "^8.14.2"

--- a/BE/src/app.module.ts
+++ b/BE/src/app.module.ts
@@ -16,6 +16,7 @@ import { ChatModule } from './chat/chat.module';
 import { CacheModule } from '@nestjs/cache-manager';
 import { RedisConfigProvider } from './config/redis.config';
 import { ReportModule } from './report/report.module';
+import { ImageModule } from './image/image.module';
 
 @Module({
   imports: [
@@ -40,6 +41,7 @@ import { ReportModule } from './report/report.module';
     LoginModule,
     ChatModule,
     ReportModule,
+    ImageModule,
   ],
   controllers: [AppController],
   providers: [

--- a/BE/src/common/S3Handler.ts
+++ b/BE/src/common/S3Handler.ts
@@ -4,7 +4,7 @@ import {
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
-import { uuid } from 'uuidv4';
+import { v4 as uuid } from 'uuid';
 import { HttpException, Injectable } from '@nestjs/common';
 
 @Injectable()

--- a/BE/src/common/greenEyeHandler.ts
+++ b/BE/src/common/greenEyeHandler.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { uuid } from 'uuidv4';
+import { v4 as uuid } from 'uuid';
 import { ConfigService } from '@nestjs/config';
 import { Injectable } from '@nestjs/common';
 

--- a/BE/src/config/s3.config.ts
+++ b/BE/src/config/s3.config.ts
@@ -1,0 +1,20 @@
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { S3Client } from '@aws-sdk/client-s3';
+
+export const S3Provider = [
+  {
+    provide: 'S3_CLIENT',
+    import: [ConfigModule],
+    inject: [ConfigService],
+    useFactory: (configService: ConfigService) => {
+      return new S3Client({
+        endpoint: configService.get('S3_ENDPOINT'),
+        region: configService.get('S3_REGION'),
+        credentials: {
+          accessKeyId: configService.get('S3_ACCESS_KEY'),
+          secretAccessKey: configService.get('S3_SECRET_KEY'),
+        },
+      });
+    },
+  },
+];

--- a/BE/src/image/image.module.ts
+++ b/BE/src/image/image.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ImageService } from './image.service';
+import { S3Provider } from '../config/s3.config';
+import { PostImageRepository } from './postImage.repository';
+
+@Module({
+  providers: [ImageService, ...S3Provider, PostImageRepository],
+  exports: [ImageService],
+})
+export class ImageModule {}

--- a/BE/src/image/image.service.spec.ts
+++ b/BE/src/image/image.service.spec.ts
@@ -1,0 +1,214 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ImageService } from './image.service';
+import { PostImageRepository } from './postImage.repository';
+import { ConfigService } from '@nestjs/config';
+import { HttpException } from '@nestjs/common';
+import { PostImageEntity } from '../entities/postImage.entity';
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'fixed-uuid-value'),
+}));
+
+const mockRepository = {
+  save: jest.fn(),
+  softDelete: jest.fn(),
+  findOne: jest.fn(),
+};
+
+const mockPostImageRepository = {
+  getRepository: jest.fn().mockReturnValue(mockRepository),
+};
+
+describe('ImageService', () => {
+  let service: ImageService;
+  let postImageRepository;
+  let s3ClientMock;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ImageService,
+        {
+          provide: PostImageRepository,
+          useValue: mockPostImageRepository,
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn((key: string) => 'mocked-value') },
+        },
+        {
+          provide: 'S3_CLIENT',
+          useValue: { send: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    service = module.get<ImageService>(ImageService);
+    postImageRepository = module.get<jest.Mock>(PostImageRepository);
+    s3ClientMock = module.get('S3_CLIENT');
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('uploadImage', function () {
+    const file: Express.Multer.File = {
+      buffer: Buffer.from('test-content'),
+      originalname: 'test.jpg',
+      mimetype: 'image/jpeg',
+      size: 1024,
+      fieldname: 'image',
+      encoding: '7bit',
+      destination: '',
+      filename: 'test.jpg',
+      path: '',
+      stream: {} as any,
+    };
+    it('should upload file', async function () {
+      s3ClientMock.send.mockReturnValue(undefined);
+      const res = await service.uploadImage(file);
+      expect(res).toEqual('mocked-value/mocked-value/fixed-uuid-value');
+    });
+
+    it('should fail to upload', function () {
+      s3ClientMock.send.mockRejectedValue(new Error('test'));
+      expect(async () => {
+        await service.uploadImage(file);
+      }).rejects.toThrowError(
+        new HttpException('업로드에 실패하였습니다.', 500),
+      );
+    });
+  });
+
+  describe('createPostImages', function () {
+    const files = [];
+    for (let i = 0; i < 7; i++) {
+      const file: Express.Multer.File = {
+        buffer: Buffer.from(`test-content ${i}`),
+        originalname: 'test.jpg',
+        mimetype: 'image/jpeg',
+        size: 1024,
+        fieldname: 'image',
+        encoding: '7bit',
+        destination: '',
+        filename: 'test.jpg',
+        path: '',
+        stream: {} as any,
+      };
+      files.push(file);
+    }
+
+    it('should create images', async function () {
+      s3ClientMock.send.mockReturnValue(undefined);
+      postImageRepository.getRepository().save.mockResolvedValue('test');
+      const res = await service.createPostImages(files, 3);
+      expect(res).toEqual('mocked-value/mocked-value/fixed-uuid-value');
+      expect(s3ClientMock.send).toHaveBeenCalledTimes(7);
+      expect(postImageRepository.getRepository().save).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fail to upload images', async function () {
+      s3ClientMock.send.mockRejectedValue(new Error('fail to upload image'));
+      await expect(async () => {
+        await service.createPostImages(files, 3);
+      }).rejects.toThrowError(
+        new HttpException('업로드에 실패하였습니다.', 500),
+      );
+    });
+
+    it('should fail to create images', async function () {
+      postImageRepository.getRepository().save.mockResolvedValue('test');
+      postImageRepository
+        .getRepository()
+        .save.mockRejectedValue(new Error('fail to create images'));
+      await expect(async () => {
+        await service.createPostImages(files, 3);
+      }).rejects.toThrowError();
+      expect(s3ClientMock.send).toHaveBeenCalledTimes(7);
+    });
+  });
+
+  describe('removePostImages', function () {
+    const imageLocations = ['test1', 'test2', 'test3'];
+    it('should remove post images', async function () {
+      await service.removePostImages(imageLocations);
+      expect(
+        postImageRepository.getRepository().softDelete,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fail to remove images', async function () {
+      postImageRepository
+        .getRepository()
+        .softDelete.mockRejectedValue(new Error('fail to remove images'));
+      await expect(async () => {
+        await service.removePostImages(imageLocations);
+      }).rejects.toThrowError();
+    });
+  });
+
+  describe('', function () {
+    const files = [];
+    for (let i = 0; i < 2; i++) {
+      const file: Express.Multer.File = {
+        buffer: Buffer.from(`test-content ${i}`),
+        originalname: 'test.jpg',
+        mimetype: 'image/jpeg',
+        size: 1024,
+        fieldname: 'image',
+        encoding: '7bit',
+        destination: '',
+        filename: 'test.jpg',
+        path: '',
+        stream: {} as any,
+      };
+      files.push(file);
+    }
+    it('should update Post Image', async function () {
+      const postImageEntity: PostImageEntity = {
+        id: 1,
+        post_id: 1,
+        image_url: 'updatedImageUrl',
+        delete_date: null,
+        post: null,
+      };
+      postImageRepository
+        .getRepository()
+        .findOne.mockResolvedValue(postImageEntity);
+      jest.spyOn(service, 'createPostImages').mockResolvedValue(undefined);
+      jest.spyOn(service, 'removePostImages').mockResolvedValue(undefined);
+      const deletedImages = ['image1', 'image2'];
+      const postId = 1;
+
+      const result = await service.updatePostImage(
+        files,
+        deletedImages,
+        postId,
+      );
+
+      expect(service.createPostImages).toHaveBeenCalledWith(files, postId);
+      expect(service.removePostImages).toHaveBeenCalledWith(deletedImages);
+      expect(postImageRepository.getRepository().findOne).toHaveBeenCalledWith({
+        where: { post_id: postId },
+        order: { id: 'ASC' },
+      });
+      expect(result).toBe('updatedImageUrl');
+    });
+
+    it('should return null', async function () {
+      jest.spyOn(service, 'createPostImages').mockResolvedValue(undefined);
+      jest.spyOn(service, 'removePostImages').mockResolvedValue(undefined);
+      postImageRepository.getRepository().findOne.mockResolvedValue(null);
+      const deletedImages = ['image1', 'image2']; // Replace with your actual deleted image data
+      const postId = 1;
+
+      const result = await service.updatePostImage(
+        files,
+        deletedImages,
+        postId,
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/BE/src/image/image.service.ts
+++ b/BE/src/image/image.service.ts
@@ -1,0 +1,68 @@
+import { HttpException, Inject, Injectable } from '@nestjs/common';
+import {
+  DeleteObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { uuid } from 'uuidv4';
+import { ConfigService } from '@nestjs/config';
+import { PostImageEntity } from '../entities/postImage.entity';
+import { PostImageRepository } from './postImage.repository';
+
+@Injectable()
+export class ImageService {
+  constructor(
+    @Inject('S3_CLIENT')
+    private readonly s3Client: S3Client,
+    private postImageRepository: PostImageRepository,
+    private configService: ConfigService,
+  ) {}
+  async uploadImage(file: Express.Multer.File) {
+    const fileName = uuid();
+    const command = new PutObjectCommand({
+      Bucket: this.configService.get('S3_BUCKET'),
+      Key: fileName,
+      ACL: 'public-read',
+      Body: file.buffer,
+    });
+    try {
+      await this.s3Client.send(command);
+      return `${this.configService.get('S3_ENDPOINT')}/${this.configService.get(
+        'S3_BUCKET',
+      )}/${fileName}`;
+    } catch (e) {
+      throw new HttpException('업로드에 실패하였습니다.', 500);
+    }
+  }
+
+  async createPostImages(
+    files: Express.Multer.File[],
+    postId: number,
+  ): Promise<string> {
+    const postImageEntities = [];
+    for (const file of files) {
+      const imageLocation = await this.uploadImage(file);
+      const postImageEntity = new PostImageEntity();
+      postImageEntity.image_url = imageLocation;
+      postImageEntity.post_id = postId;
+      postImageEntities.push(postImageEntity);
+    }
+    await this.postImageRepository
+      .getRepository(PostImageEntity)
+      .save(postImageEntities);
+    return postImageEntities[0].image_url;
+  }
+
+  async deleteImage(fileLocation: string) {
+    const fileKey = fileLocation.split('/').pop();
+    const command = new DeleteObjectCommand({
+      Bucket: this.configService.get('S3_BUCKET'),
+      Key: fileKey,
+    });
+    try {
+      await this.s3Client.send(command);
+    } catch (e) {
+      throw new HttpException('이미지 삭제에 실패하였습니다.', 500);
+    }
+  }
+}

--- a/BE/src/image/image.service.ts
+++ b/BE/src/image/image.service.ts
@@ -4,7 +4,7 @@ import {
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
-import { uuid } from 'uuidv4';
+import { v4 as uuid } from 'uuid';
 import { ConfigService } from '@nestjs/config';
 import { PostImageEntity } from '../entities/postImage.entity';
 import { PostImageRepository } from './postImage.repository';

--- a/BE/src/image/postImage.repository.ts
+++ b/BE/src/image/postImage.repository.ts
@@ -1,0 +1,11 @@
+import { BaseRepository } from '../common/base.repository';
+import { DataSource } from 'typeorm';
+import { Inject, Injectable, Scope } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+
+@Injectable({ scope: Scope.REQUEST })
+export class PostImageRepository extends BaseRepository {
+  constructor(dataSource: DataSource, @Inject(REQUEST) req: Request) {
+    super(dataSource, req);
+  }
+}

--- a/BE/src/post/post.controller.ts
+++ b/BE/src/post/post.controller.ts
@@ -74,8 +74,9 @@ export class PostController {
   @Patch('/:id')
   @ApiOperation({ summary: 'fix post context', description: '게시글 수정' })
   @UseInterceptors(FilesInterceptor('image', 12))
+  @UseInterceptors(TransactionInterceptor)
   async postModify(
-    @Param('id') id: number,
+    @Param('id') postId: number,
     @UploadedFiles(new FilesSizeValidator())
     files: Array<Express.Multer.File>,
     @MultiPartBody(
@@ -85,18 +86,13 @@ export class PostController {
     body: UpdatePostDto,
     @UserHash() userId,
   ) {
-    const isFixed = await this.postService.updatePostById(
-      id,
-      body,
+    await this.postService.checkAuth(postId, userId);
+    const updatedThumbnail = await this.imageService.updatePostImage(
       files,
-      userId,
+      body.deleted_images,
+      postId,
     );
-
-    if (isFixed) {
-      return HttpCode(200);
-    } else {
-      throw new HttpException('서버 오류입니다.', 500);
-    }
+    await this.postService.updatePostById(postId, body, updatedThumbnail);
   }
 
   @Delete('/:id')

--- a/BE/src/post/post.module.ts
+++ b/BE/src/post/post.module.ts
@@ -9,6 +9,7 @@ import { BlockUserEntity } from '../entities/blockUser.entity';
 import { BlockPostEntity } from '../entities/blockPost.entity';
 import { AuthGuard } from 'src/common/guard/auth.guard';
 import { PostRepository } from './post.repository';
+import { ImageModule } from '../image/image.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { PostRepository } from './post.repository';
       BlockUserEntity,
       BlockPostEntity,
     ]),
+    ImageModule,
   ],
   controllers: [PostController],
   providers: [PostService, S3Handler, AuthGuard, PostRepository],


### PR DESCRIPTION
## 이슈
- #579

## 체크리스트
- [x] 이미지 서비스 분리
- [x] 게시글 등록 및 수정 트랜잭션 적용
- [x] 테스트 코드 작성

## 고민한 내용
- image에 대한 처리가 여러 모듈에서 이루어지고 있는데 공통으로 뺴서 관리하는 것이 편할 것 같아 모듈을 새로 만들었다.
- 테스트 시에도 의존성이 분리되어 더 테스트 하기 용이해졌다.
- 객체를 반환하는 메서드가 있고 반환된 메서드를 모킹하는 부분에서 애를 많이 먹었는데 이때 모킹에서 중요한 점은 객체를 반환시킬떄 항상 동일한 객체를 반환시켜야한다. 

## 스크린샷
