### PR TITLE
[iOS/#591] Network Layer Combine을 사용할 수 있도록 수정

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		59110F042B1725C20009E9AC /* NotificationName+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59110F032B1725C20009E9AC /* NotificationName+.swift */; };
 		59457BC72B233EE5003F798C /* UIImage+Resize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59457BC62B233EE5003F798C /* UIImage+Resize.swift */; };
 		59457BC92B237615003F798C /* PatchUserDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59457BC82B237615003F798C /* PatchUserDTO.swift */; };
+		5958B9A92B468510005E3868 /* NetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5958B9A82B468510005E3868 /* NetworkService.swift */; };
 		5959A8182B28184200F6A3FC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5959A8172B28184200F6A3FC /* LaunchScreen.storyboard */; };
 		596AD1F22B259147005860B3 /* BlockedUsersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596AD1F12B259147005860B3 /* BlockedUsersViewModel.swift */; };
 		596AD1F42B2593E1005860B3 /* BlockedUserDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596AD1F32B2593E1005860B3 /* BlockedUserDTO.swift */; };
@@ -71,6 +72,7 @@
 		59AABDE32B0E272C002F6D0E /* PostCreateTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */; };
 		59AABDE52B0E2D47002F6D0E /* PostCreateDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */; };
 		59AADE382B22086400C3E17D /* EditProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59AADE372B22086400C3E17D /* EditProfileViewModel.swift */; };
+		59ACF50A2B46E4D00034E709 /* CombineAuthInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59ACF5092B46E4D00034E709 /* CombineAuthInterceptor.swift */; };
 		59B6E2732B17938C000864F9 /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B6E2722B17938C000864F9 /* MyPageViewModel.swift */; };
 		59B6E27C2B185FD2000864F9 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 59B6E27B2B185FD2000864F9 /* GoogleService-Info.plist */; };
 		59B6E27F2B18604D000864F9 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 59B6E27E2B18604D000864F9 /* FirebaseAnalytics */; };
@@ -207,6 +209,7 @@
 		59110F032B1725C20009E9AC /* NotificationName+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+.swift"; sourceTree = "<group>"; };
 		59457BC62B233EE5003F798C /* UIImage+Resize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resize.swift"; sourceTree = "<group>"; };
 		59457BC82B237615003F798C /* PatchUserDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchUserDTO.swift; sourceTree = "<group>"; };
+		5958B9A82B468510005E3868 /* NetworkService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkService.swift; sourceTree = "<group>"; };
 		5959A8172B28184200F6A3FC /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		596AD1F12B259147005860B3 /* BlockedUsersViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUsersViewModel.swift; sourceTree = "<group>"; };
 		596AD1F32B2593E1005860B3 /* BlockedUserDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUserDTO.swift; sourceTree = "<group>"; };
@@ -224,6 +227,7 @@
 		59AABDE22B0E272C002F6D0E /* PostCreateTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateTimeView.swift; sourceTree = "<group>"; };
 		59AABDE42B0E2D47002F6D0E /* PostCreateDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateDetailView.swift; sourceTree = "<group>"; };
 		59AADE372B22086400C3E17D /* EditProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewModel.swift; sourceTree = "<group>"; };
+		59ACF5092B46E4D00034E709 /* CombineAuthInterceptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CombineAuthInterceptor.swift; sourceTree = "<group>"; };
 		59B6E2722B17938C000864F9 /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		59B6E27B2B185FD2000864F9 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		59BA10F92B1CC3F700F30DB8 /* FCMManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMManager.swift; sourceTree = "<group>"; };
@@ -871,6 +875,8 @@
 			children = (
 				8F95CF9B2B0C81640024631F /* APIProvider.swift */,
 				445D62AF2B1DD6EC005DD3B1 /* AuthInterceptor.swift */,
+				5958B9A82B468510005E3868 /* NetworkService.swift */,
+				59ACF5092B46E4D00034E709 /* CombineAuthInterceptor.swift */,
 			);
 			path = APIProvider;
 			sourceTree = "<group>";
@@ -1289,10 +1295,12 @@
 				59AABDDF2B0E1AE1002F6D0E /* PostCreateTitleView.swift in Sources */,
 				44A59F5A2B3BFC4A00736A34 /* PostListUseCase.swift in Sources */,
 				8F8F0B952B1DC0CE00BE97D2 /* PostRoomResponseDTO.swift in Sources */,
+				5958B9A92B468510005E3868 /* NetworkService.swift in Sources */,
 				8F9939552B29E1BD009FF9F8 /* ImageCache.swift in Sources */,
 				444A509A2B0CE94E00454397 /* DateView.swift in Sources */,
 				59E2C1622B248AB9004428F7 /* MyHiddenPostsViewModel.swift in Sources */,
 				8F81E8422B247A8B00C5687C /* SearchResultViewModel.swift in Sources */,
+				59ACF50A2B46E4D00034E709 /* CombineAuthInterceptor.swift in Sources */,
 				8F81E8402B246C0F00C5687C /* SearchResultViewController.swift in Sources */,
 				59AABDE32B0E272C002F6D0E /* PostCreateTimeView.swift in Sources */,
 				59E6A20B2B1F3AD300A2DF21 /* RentPostTableViewCell.swift in Sources */,

--- a/iOS/Village/Village/Network/APIProvider/CombineAuthInterceptor.swift
+++ b/iOS/Village/Village/Network/APIProvider/CombineAuthInterceptor.swift
@@ -1,0 +1,90 @@
+//
+//  CombineAuthInterceptor.swift
+//  Village
+//
+//  Created by 조성민 on 1/4/24.
+//
+
+import Foundation
+
+protocol CombineInterceptor {
+    
+    func adapt(request: URLRequest) -> URLRequest?
+    func retry(request: URLRequest, error: NetworkError) -> RetryResult
+    
+}
+
+final class CombineAuthInterceptor: CombineInterceptor {
+    
+    private let session: URLSession
+    private var attempt: Int
+    private let maxAttempt: Int
+    
+    init(session: URLSession = .shared, maxAttempt: Int = 3) {
+        self.session = session
+        self.attempt = 0
+        self.maxAttempt = maxAttempt
+    }
+    
+    func adapt(request: URLRequest) -> URLRequest? {
+        guard let accessToken = JWTManager.shared.get()?.accessToken else { return request }
+        
+        var urlRequest = request
+        urlRequest.addValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        return urlRequest
+    }
+    
+    func retry(request: URLRequest, error: NetworkError) -> RetryResult {
+        if attempt > maxAttempt {
+            attempt = 0
+            return .doNotRetry
+        }
+        attempt += 1
+        
+        switch error {
+        case .serverError(.unauthorized):
+            do {
+                try refreshToken()
+                return .retry
+            } catch let error {
+                attempt = 0
+                NotificationCenter.default.post(name: .shouldLogin, object: nil)
+                return .doNotRetryWithError(error)
+            }
+        default:
+            return .retry
+        }
+    }
+    
+}
+
+private extension CombineAuthInterceptor {
+    
+    func refreshToken() throws {
+        guard let refreshToken = JWTManager.shared.get()?.refreshToken else { return }
+        
+        do {
+            let request = try APIEndPoints.tokenRefresh(refreshToken: refreshToken).makeURLRequest()
+            let result = URLSession.shared.dataTaskPublisher(for: request)
+                .tryMap { (data, response) in
+                    guard let response = response as? HTTPURLResponse,
+                          (200..<300).contains(response.statusCode) else {
+                        throw NetworkError.refreshTokenExpired
+                    }
+                    let newToken = try JSONDecoder().decode(AuthenticationToken.self, from: data)
+                    try JWTManager.shared.update(token: newToken)
+                }
+                .mapError { error in
+                    guard let networkError = error as? NetworkError else {
+                        return NetworkError.unknownError
+                    }
+                    return networkError
+                }
+                .eraseToAnyPublisher()
+                
+        } catch {
+            throw error
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Network/APIProvider/NetworkAPI.swift
+++ b/iOS/Village/Village/Network/APIProvider/NetworkAPI.swift
@@ -1,8 +1,0 @@
-//
-//  NetworkAPI.swift
-//  Village
-//
-//  Created by 조성민 on 1/3/24.
-//
-
-import Foundation

--- a/iOS/Village/Village/Network/APIProvider/NetworkService.swift
+++ b/iOS/Village/Village/Network/APIProvider/NetworkService.swift
@@ -64,8 +64,8 @@ final class NetworkService {
                 let publisher = URLSession.shared.dataTaskPublisher(for: request)
                 
                 return publisher
-                    .tryMap { [weak self] output in
-                        try self?.checkStatusCode(output.response)
+                    .tryMap { [weak self] (_, response) in
+                        try self?.checkStatusCode(response)
                     }
                     .mapError { [weak self] error in
                         guard let networkError = error as? NetworkError else { return NetworkError.unknownError }

--- a/iOS/Village/Village/Network/APIProvider/NetworkService.swift
+++ b/iOS/Village/Village/Network/APIProvider/NetworkService.swift
@@ -1,0 +1,140 @@
+//
+//  NetworkService.swift
+//  Village
+//
+//  Created by 조성민 on 1/4/24.
+//
+
+import Foundation
+import Combine
+
+final class NetworkService {
+    
+    static let shared = NetworkService()
+    
+    private let interceptor = CombineAuthInterceptor()
+    
+    func request<R: Decodable, E: Requestable&Responsable>(_ req: E) -> AnyPublisher<R, NetworkError> where E.Response == R {
+        while true {
+            do {
+                guard let request = interceptor.adapt(request: try req.makeURLRequest()) else {
+                    throw NetworkError.urlRequestError
+                }
+                
+                let publisher = URLSession.shared.dataTaskPublisher(for: request)
+                
+                return publisher
+                    .tryMap { [weak self] output in
+                        try self?.checkStatusCode(output.response)
+                        return output.data
+                    }
+                    .decode(type: R.self, decoder: JSONDecoder())
+                    .mapError { [weak self] error in
+                        guard let networkError = error as? NetworkError else { return NetworkError.unknownError }
+                        switch self?.interceptor.retry(
+                            request: request,
+                            error: networkError
+                        ) {
+                        case .doNotRetry:
+                            return networkError
+                        case .doNotRetryWithError(let err):
+                            dump(err)
+                            return NetworkError.unknownError
+                        default:
+                            break
+                        }
+                        
+                        return networkError
+                    }
+                    .eraseToAnyPublisher()
+            } catch {
+                return Fail<R, NetworkError>(error: NetworkError.urlRequestError)
+                    .eraseToAnyPublisher()
+            }
+        }
+    }
+    
+    func request<R: Decodable, E: Requestable>(_ req: E) -> AnyPublisher<R, NetworkError> {
+        while true {
+            do {
+                guard let request = interceptor.adapt(request: try req.makeURLRequest()) else {
+                    throw NetworkError.urlRequestError
+                }
+                
+                let publisher = URLSession.shared.dataTaskPublisher(for: request)
+                
+                return publisher
+                    .tryMap { [weak self] output in
+                        try self?.checkStatusCode(output.response)
+                        return output.data
+                    }
+                    .decode(type: R.self, decoder: JSONDecoder())
+                    .mapError { [weak self] error in
+                        guard let networkError = error as? NetworkError else { return NetworkError.unknownError }
+                        switch self?.interceptor.retry(
+                            request: request,
+                            error: networkError
+                        ) {
+                        case .doNotRetry:
+                            return networkError
+                        case .doNotRetryWithError(let err):
+                            dump(err)
+                            return NetworkError.unknownError
+                        default:
+                            break
+                        }
+                        
+                        return networkError
+                    }
+                    .eraseToAnyPublisher()
+            } catch {
+                return Fail<R, NetworkError>(error: NetworkError.urlRequestError)
+                    .eraseToAnyPublisher()
+            }
+        }
+    }
+    
+    func requestLoadImage(url: String) -> AnyPublisher<Data, NetworkError> {
+        guard let url = URL(string: url) else {
+            return AnyPublisher(
+                Fail<Data, NetworkError>(error: NetworkError.urlRequestError)
+            )
+        }
+        
+        if let cachedImage = ImageCache.shared.getImageData(for: url as NSURL) {
+            return Future<Data, NetworkError> { promise in
+                promise(.success(Data(cachedImage)))
+            }
+            .eraseToAnyPublisher()
+        } else {
+            let publisher = URLSession.shared.dataTaskPublisher(for: url)
+            
+            return publisher
+                .tryMap { (data, response) in
+                    try self.checkStatusCode(response)
+                    ImageCache.shared.setImageData(data as NSData, for: url as NSURL)
+                    return data
+                }
+                .mapError { error in
+                    if let networkError = error as? NetworkError {
+                        return networkError
+                    } else {
+                        return NetworkError.unknownError
+                    }
+                }
+                .eraseToAnyPublisher()
+        }
+    }
+    
+    private func checkStatusCode(_ response: URLResponse) throws {
+        guard let response = response as? HTTPURLResponse else {
+            throw NetworkError.unknownError
+        }
+        
+        guard (200..<300).contains(response.statusCode) else {
+            let serverError = ServerError(rawValue: response.statusCode) ?? .unknown
+            throw NetworkError.serverError(serverError)
+        }
+    }
+    
+}


### PR DESCRIPTION
## 이슈
- #591

## 체크리스트
- [x] 이전 네트워크에서 동작하던 모든 기능을 대체할 수 있다.
- [x] Combine을 사용하여 send하지 않아도 바로 받은 데이터를 사용할 수 있다.

## 고민한 내용
- Interceptor 적용
    Interceptor를 적용하는 과정에서 기존의 방식은 attempt 수를 밖에서 정해줘서 반복했다. 에러 처리와 combine operator를 사용하면서 내부에서 attempt를 관리하는 것이 편리하다고 판단하여 Interceptor 내부에서 attempt를 관리하도록 수정했다.
- Error 처리
    Error 처리를 tryMap과 mapError를 사용하여 편리하게 처리한다고 생각되기도 한다. 하지만, AnyPublisher 형식을 맞춰야 했기 때문에 모든 에러를 NetworkError로 변환해줘야 했다. 이 부분이 Combine의 단점이라고 생각되기도 하여 추후에 개선할 부분이라고 생각된다. 