### PR TITLE
[iOS/#597] 채팅방 Clean Architecture 도입

### DIFF
--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		8F95CF9C2B0C81640024631F /* APIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F95CF9B2B0C81640024631F /* APIProvider.swift */; };
 		8F97D06C2B222EFA00A19754 /* OpponentChatTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F97D06B2B222EF900A19754 /* OpponentChatTableViewCell.swift */; };
 		8F9939552B29E1BD009FF9F8 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9939542B29E1BD009FF9F8 /* ImageCache.swift */; };
+		8FB8BFFF2B4F7C820006E903 /* PostDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB8BFFE2B4F7C820006E903 /* PostDetail.swift */; };
 		8FBB3BB92B26B431001876F5 /* GetAllReadResponseDTO .swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBB3BB82B26B431001876F5 /* GetAllReadResponseDTO .swift */; };
 		8FBB65CC2B20587B00C6A133 /* BlockedUserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBB65CB2B20587B00C6A133 /* BlockedUserTableViewCell.swift */; };
 		8FBB65CE2B20C21100C6A133 /* GetChatListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */; };
@@ -299,6 +300,7 @@
 		8F95CF9B2B0C81640024631F /* APIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProvider.swift; sourceTree = "<group>"; };
 		8F97D06B2B222EF900A19754 /* OpponentChatTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpponentChatTableViewCell.swift; sourceTree = "<group>"; };
 		8F9939542B29E1BD009FF9F8 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
+		8FB8BFFE2B4F7C820006E903 /* PostDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetail.swift; sourceTree = "<group>"; };
 		8FBB3BB82B26B431001876F5 /* GetAllReadResponseDTO .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GetAllReadResponseDTO .swift"; sourceTree = "<group>"; };
 		8FBB65CB2B20587B00C6A133 /* BlockedUserTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUserTableViewCell.swift; sourceTree = "<group>"; };
 		8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChatListResponseDTO.swift; sourceTree = "<group>"; };
@@ -416,6 +418,7 @@
 			children = (
 				4416D4822B171C730052BF33 /* AuthenticationToken.swift */,
 				44A59F562B3BF77C00736A34 /* PostListItem.swift */,
+				8FB8BFFE2B4F7C820006E903 /* PostDetail.swift */,
 				8FF472952B4E915F00B9BA95 /* ChatRoomData.swift */,
 			);
 			path = Entity;
@@ -1353,6 +1356,7 @@
 				59D8F1072B103F4800A08E02 /* PostCreateUseCase.swift in Sources */,
 				8F8F0B8B2B1D985A00BE97D2 /* BlockedUserViewController.swift in Sources */,
 				8F8F0B8D2B1DA91500BE97D2 /* HiddenRentPostTableViewCell.swift in Sources */,
+				8FB8BFFF2B4F7C820006E903 /* PostDetail.swift in Sources */,
 				59AADE382B22086400C3E17D /* EditProfileViewModel.swift in Sources */,
 				8FBD4E4A2B4A746900D32488 /* ChatRoomRepository.swift in Sources */,
 				44FC33692B2986E900FF4D65 /* ImageDetailView.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -138,6 +138,9 @@
 		8FBD4E482B4A745300D32488 /* DefaultChatRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E472B4A745300D32488 /* DefaultChatRoomRepository.swift */; };
 		8FBD4E4A2B4A746900D32488 /* ChatRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E492B4A746900D32488 /* ChatRoomRepository.swift */; };
 		8FBD4E4C2B4A74A800D32488 /* ChatRoomUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E4B2B4A74A800D32488 /* ChatRoomUseCase.swift */; };
+		8FBD4E4E2B4A9E2600D32488 /* DefaultPostDetailRepostory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E4D2B4A9E2600D32488 /* DefaultPostDetailRepostory.swift */; };
+		8FBD4E502B4A9E3200D32488 /* PostDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E4F2B4A9E3200D32488 /* PostDetailRepository.swift */; };
+		8FBD4E522B4A9E3E00D32488 /* PostDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E512B4A9E3E00D32488 /* PostDetailUseCase.swift */; };
 		8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B0B2B048B1300660530 /* HomeViewController.swift */; };
 		8FBE3B122B04CF6300660530 /* UILabel+SetTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B112B04CF6300660530 /* UILabel+SetTitle.swift */; };
 		8FBE3B142B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B132B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift */; };
@@ -297,6 +300,9 @@
 		8FBD4E472B4A745300D32488 /* DefaultChatRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChatRoomRepository.swift; sourceTree = "<group>"; };
 		8FBD4E492B4A746900D32488 /* ChatRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomRepository.swift; sourceTree = "<group>"; };
 		8FBD4E4B2B4A74A800D32488 /* ChatRoomUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomUseCase.swift; sourceTree = "<group>"; };
+		8FBD4E4D2B4A9E2600D32488 /* DefaultPostDetailRepostory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPostDetailRepostory.swift; sourceTree = "<group>"; };
+		8FBD4E4F2B4A9E3200D32488 /* PostDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailRepository.swift; sourceTree = "<group>"; };
+		8FBD4E512B4A9E3E00D32488 /* PostDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailUseCase.swift; sourceTree = "<group>"; };
 		8FBE3B0B2B048B1300660530 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		8FBE3B112B04CF6300660530 /* UILabel+SetTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+SetTitle.swift"; sourceTree = "<group>"; };
 		8FBE3B132B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+MakeSFSymbolButton.swift"; sourceTree = "<group>"; };
@@ -732,6 +738,7 @@
 				59EA94BA2B359A23007EAA42 /* ReportRepository.swift */,
 				44A59F5B2B3BFC7700736A34 /* PostListRepository.swift */,
 				8FBD4E492B4A746900D32488 /* ChatRoomRepository.swift */,
+				8FBD4E4F2B4A9E3200D32488 /* PostDetailRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -743,6 +750,7 @@
 				59EA94C22B35A331007EAA42 /* ReportUseCase.swift */,
 				44A59F592B3BFC4A00736A34 /* PostListUseCase.swift */,
 				8FBD4E4B2B4A74A800D32488 /* ChatRoomUseCase.swift */,
+				8FBD4E512B4A9E3E00D32488 /* PostDetailUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -753,6 +761,7 @@
 				59EA94C02B359ABB007EAA42 /* DefaultReportRepository.swift */,
 				44A59F5D2B3BFC9C00736A34 /* DefaultPostListRepository.swift */,
 				8FBD4E472B4A745300D32488 /* DefaultChatRoomRepository.swift */,
+				8FBD4E4D2B4A9E2600D32488 /* DefaultPostDetailRepostory.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -1254,6 +1263,7 @@
 				4416D48C2B174C7A0052BF33 /* KeychainManager.swift in Sources */,
 				59457BC72B233EE5003F798C /* UIImage+Resize.swift in Sources */,
 				5980D75F2B0FB6DB00A6B370 /* PostCreateRepository.swift in Sources */,
+				8FBD4E502B4A9E3200D32488 /* PostDetailRepository.swift in Sources */,
 				4416D48E2B174CBA0052BF33 /* KeychainError.swift in Sources */,
 				4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */,
 				8FBD4E482B4A745300D32488 /* DefaultChatRoomRepository.swift in Sources */,
@@ -1305,6 +1315,7 @@
 				59AABDDF2B0E1AE1002F6D0E /* PostCreateTitleView.swift in Sources */,
 				44A59F5A2B3BFC4A00736A34 /* PostListUseCase.swift in Sources */,
 				8F8F0B952B1DC0CE00BE97D2 /* PostRoomResponseDTO.swift in Sources */,
+				8FBD4E4E2B4A9E2600D32488 /* DefaultPostDetailRepostory.swift in Sources */,
 				5958B9A92B468510005E3868 /* NetworkService.swift in Sources */,
 				8F9939552B29E1BD009FF9F8 /* ImageCache.swift in Sources */,
 				444A509A2B0CE94E00454397 /* DateView.swift in Sources */,
@@ -1347,6 +1358,7 @@
 				8F95CF9C2B0C81640024631F /* APIProvider.swift in Sources */,
 				8F81E8462B248B0A00C5687C /* SearchRequstTableViewCell.swift in Sources */,
 				446B61062B2602A200A361CB /* PostSegmentedControl.swift in Sources */,
+				8FBD4E522B4A9E3E00D32488 /* PostDetailUseCase.swift in Sources */,
 				59AABDE12B0E1BB8002F6D0E /* PostCreatePriceView.swift in Sources */,
 				8F8F0B832B1B36DD00BE97D2 /* ChatListTableViewCell.swift in Sources */,
 				8FC7FE742B05CE9A00B91D3B /* HomeViewModel.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -152,6 +152,8 @@
 		8FD52A482B09D1AD005EE367 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD52A472B09D1AD005EE367 /* MyPageViewController.swift */; };
 		8FD52A4B2B0B0A2F005EE367 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD52A4A2B0B0A2F005EE367 /* SearchViewController.swift */; };
 		8FD52A512B0B51AF005EE367 /* ChatRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FD52A502B0B51AF005EE367 /* ChatRoomViewController.swift */; };
+		8FF472962B4E915F00B9BA95 /* ChatRoomData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF472952B4E915F00B9BA95 /* ChatRoomData.swift */; };
+		8FF472982B4E9FE200B9BA95 /* ChatDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF472972B4E9FE200B9BA95 /* ChatDTO.swift */; };
 		8FF7E60D2B0F38A500B6D678 /* ChatListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF7E60B2B0F38A500B6D678 /* ChatListViewController.swift */; };
 		8FF7E61A2B106FBB00B6D678 /* ChatList.json in Resources */ = {isa = PBXBuildFile; fileRef = 8FF7E6192B106FBB00B6D678 /* ChatList.json */; };
 		8FF7E61D2B10721400B6D678 /* ChatListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FF7E61C2B10721400B6D678 /* ChatListViewModel.swift */; };
@@ -317,6 +319,8 @@
 		8FD52A472B09D1AD005EE367 /* MyPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
 		8FD52A4A2B0B0A2F005EE367 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		8FD52A502B0B51AF005EE367 /* ChatRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomViewController.swift; sourceTree = "<group>"; };
+		8FF472952B4E915F00B9BA95 /* ChatRoomData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomData.swift; sourceTree = "<group>"; };
+		8FF472972B4E9FE200B9BA95 /* ChatDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDTO.swift; sourceTree = "<group>"; };
 		8FF7E60B2B0F38A500B6D678 /* ChatListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatListViewController.swift; sourceTree = "<group>"; };
 		8FF7E6192B106FBB00B6D678 /* ChatList.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ChatList.json; sourceTree = "<group>"; };
 		8FF7E61C2B10721400B6D678 /* ChatListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatListViewModel.swift; sourceTree = "<group>"; };
@@ -412,6 +416,7 @@
 			children = (
 				4416D4822B171C730052BF33 /* AuthenticationToken.swift */,
 				44A59F562B3BF77C00736A34 /* PostListItem.swift */,
+				8FF472952B4E915F00B9BA95 /* ChatRoomData.swift */,
 			);
 			path = Entity;
 			sourceTree = "<group>";
@@ -514,6 +519,7 @@
 				8F8F0B922B1DC0C300BE97D2 /* PostRoomRequestDTO.swift */,
 				8F8F0B942B1DC0CE00BE97D2 /* PostRoomResponseDTO.swift */,
 				8F1E2CED2B1F163D00179E34 /* ChatRoomResponseDTO.swift */,
+				8FF472972B4E9FE200B9BA95 /* ChatDTO.swift */,
 				8F8F0B842B1C7A5800BE97D2 /* ChatRoomRequestDTO.swift */,
 				8F8F0B8E2B1DB2EE00BE97D2 /* PostMuteResponseDTO.swift */,
 				8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */,
@@ -1289,6 +1295,7 @@
 				8F1B53362B0E0396006D8982 /* PostListRequestDTO.swift in Sources */,
 				5900F92E2B2AD7570065B7F6 /* MyPageTableViewCell.swift in Sources */,
 				8FBB3BB92B26B431001876F5 /* GetAllReadResponseDTO .swift in Sources */,
+				8FF472982B4E9FE200B9BA95 /* ChatDTO.swift in Sources */,
 				8F3D7A3A2B173B7C00370536 /* WebSocketError.swift in Sources */,
 				8FBE3B122B04CF6300660530 /* UILabel+SetTitle.swift in Sources */,
 				4416D4762B15E25A0052BF33 /* MultipartFormData.swift in Sources */,
@@ -1342,6 +1349,7 @@
 				59D8F1032B0FC4F700A08E02 /* PostCreateViewModel.swift in Sources */,
 				8F3D7A382B171B8400370536 /* WebSocket.swift in Sources */,
 				59110F042B1725C20009E9AC /* NotificationName+.swift in Sources */,
+				8FF472962B4E915F00B9BA95 /* ChatRoomData.swift in Sources */,
 				59D8F1072B103F4800A08E02 /* PostCreateUseCase.swift in Sources */,
 				8F8F0B8B2B1D985A00BE97D2 /* BlockedUserViewController.swift in Sources */,
 				8F8F0B8D2B1DA91500BE97D2 /* HiddenRentPostTableViewCell.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		8F97D06C2B222EFA00A19754 /* OpponentChatTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F97D06B2B222EF900A19754 /* OpponentChatTableViewCell.swift */; };
 		8F9939552B29E1BD009FF9F8 /* ImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9939542B29E1BD009FF9F8 /* ImageCache.swift */; };
 		8FB8BFFF2B4F7C820006E903 /* PostDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB8BFFE2B4F7C820006E903 /* PostDetail.swift */; };
+		8FB8C0012B4F7DFF0006E903 /* UserDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FB8C0002B4F7DFF0006E903 /* UserDetail.swift */; };
 		8FBB3BB92B26B431001876F5 /* GetAllReadResponseDTO .swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBB3BB82B26B431001876F5 /* GetAllReadResponseDTO .swift */; };
 		8FBB65CC2B20587B00C6A133 /* BlockedUserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBB65CB2B20587B00C6A133 /* BlockedUserTableViewCell.swift */; };
 		8FBB65CE2B20C21100C6A133 /* GetChatListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */; };
@@ -301,6 +302,7 @@
 		8F97D06B2B222EF900A19754 /* OpponentChatTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpponentChatTableViewCell.swift; sourceTree = "<group>"; };
 		8F9939542B29E1BD009FF9F8 /* ImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCache.swift; sourceTree = "<group>"; };
 		8FB8BFFE2B4F7C820006E903 /* PostDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetail.swift; sourceTree = "<group>"; };
+		8FB8C0002B4F7DFF0006E903 /* UserDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetail.swift; sourceTree = "<group>"; };
 		8FBB3BB82B26B431001876F5 /* GetAllReadResponseDTO .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GetAllReadResponseDTO .swift"; sourceTree = "<group>"; };
 		8FBB65CB2B20587B00C6A133 /* BlockedUserTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUserTableViewCell.swift; sourceTree = "<group>"; };
 		8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChatListResponseDTO.swift; sourceTree = "<group>"; };
@@ -419,6 +421,7 @@
 				4416D4822B171C730052BF33 /* AuthenticationToken.swift */,
 				44A59F562B3BF77C00736A34 /* PostListItem.swift */,
 				8FB8BFFE2B4F7C820006E903 /* PostDetail.swift */,
+				8FB8C0002B4F7DFF0006E903 /* UserDetail.swift */,
 				8FF472952B4E915F00B9BA95 /* ChatRoomData.swift */,
 			);
 			path = Entity;
@@ -1368,6 +1371,7 @@
 				5979BA7C2B08AE3C00FFF215 /* UITextField+.swift in Sources */,
 				4416D44A2B148A7A0052BF33 /* AppTabBarController.swift in Sources */,
 				8FF7E61D2B10721400B6D678 /* ChatListViewModel.swift in Sources */,
+				8FB8C0012B4F7DFF0006E903 /* UserDetail.swift in Sources */,
 				8FD52A482B09D1AD005EE367 /* MyPageViewController.swift in Sources */,
 				446B610B2B26439D00A361CB /* PostType.swift in Sources */,
 				8F3D79E02B136C6800370536 /* ChatRoomViewModel.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -141,6 +141,9 @@
 		8FBD4E4E2B4A9E2600D32488 /* DefaultPostDetailRepostory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E4D2B4A9E2600D32488 /* DefaultPostDetailRepostory.swift */; };
 		8FBD4E502B4A9E3200D32488 /* PostDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E4F2B4A9E3200D32488 /* PostDetailRepository.swift */; };
 		8FBD4E522B4A9E3E00D32488 /* PostDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E512B4A9E3E00D32488 /* PostDetailUseCase.swift */; };
+		8FBD4E542B4AC04A00D32488 /* UserDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E532B4AC04A00D32488 /* UserDetailRepository.swift */; };
+		8FBD4E562B4AC05B00D32488 /* DefaultUserDetailRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E552B4AC05B00D32488 /* DefaultUserDetailRepository.swift */; };
+		8FBD4E582B4AC06700D32488 /* UserDetailUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E572B4AC06700D32488 /* UserDetailUseCase.swift */; };
 		8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B0B2B048B1300660530 /* HomeViewController.swift */; };
 		8FBE3B122B04CF6300660530 /* UILabel+SetTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B112B04CF6300660530 /* UILabel+SetTitle.swift */; };
 		8FBE3B142B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B132B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift */; };
@@ -303,6 +306,9 @@
 		8FBD4E4D2B4A9E2600D32488 /* DefaultPostDetailRepostory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultPostDetailRepostory.swift; sourceTree = "<group>"; };
 		8FBD4E4F2B4A9E3200D32488 /* PostDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailRepository.swift; sourceTree = "<group>"; };
 		8FBD4E512B4A9E3E00D32488 /* PostDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailUseCase.swift; sourceTree = "<group>"; };
+		8FBD4E532B4AC04A00D32488 /* UserDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailRepository.swift; sourceTree = "<group>"; };
+		8FBD4E552B4AC05B00D32488 /* DefaultUserDetailRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultUserDetailRepository.swift; sourceTree = "<group>"; };
+		8FBD4E572B4AC06700D32488 /* UserDetailUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDetailUseCase.swift; sourceTree = "<group>"; };
 		8FBE3B0B2B048B1300660530 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		8FBE3B112B04CF6300660530 /* UILabel+SetTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+SetTitle.swift"; sourceTree = "<group>"; };
 		8FBE3B132B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+MakeSFSymbolButton.swift"; sourceTree = "<group>"; };
@@ -739,6 +745,7 @@
 				44A59F5B2B3BFC7700736A34 /* PostListRepository.swift */,
 				8FBD4E492B4A746900D32488 /* ChatRoomRepository.swift */,
 				8FBD4E4F2B4A9E3200D32488 /* PostDetailRepository.swift */,
+				8FBD4E532B4AC04A00D32488 /* UserDetailRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -751,6 +758,7 @@
 				44A59F592B3BFC4A00736A34 /* PostListUseCase.swift */,
 				8FBD4E4B2B4A74A800D32488 /* ChatRoomUseCase.swift */,
 				8FBD4E512B4A9E3E00D32488 /* PostDetailUseCase.swift */,
+				8FBD4E572B4AC06700D32488 /* UserDetailUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -762,6 +770,7 @@
 				44A59F5D2B3BFC9C00736A34 /* DefaultPostListRepository.swift */,
 				8FBD4E472B4A745300D32488 /* DefaultChatRoomRepository.swift */,
 				8FBD4E4D2B4A9E2600D32488 /* DefaultPostDetailRepostory.swift */,
+				8FBD4E552B4AC05B00D32488 /* DefaultUserDetailRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -1250,6 +1259,7 @@
 				59BD5DC92B0C760500FEB80F /* UIStackView+.swift in Sources */,
 				596AD1F22B259147005860B3 /* BlockedUsersViewModel.swift in Sources */,
 				59E2C1662B24B6D9004428F7 /* RequestFilterDTO.swift in Sources */,
+				8FBD4E582B4AC06700D32488 /* UserDetailUseCase.swift in Sources */,
 				44FC336B2B2A023C00FF4D65 /* NSItemProvider+.swift in Sources */,
 				8F1E2CEE2B1F163D00179E34 /* ChatRoomResponseDTO.swift in Sources */,
 				59E6A20F2B205C8500A2DF21 /* RequestPostSummaryView.swift in Sources */,
@@ -1258,6 +1268,7 @@
 				59E6A2072B1F374B00A2DF21 /* MyPostsViewModel.swift in Sources */,
 				59BA10FA2B1CC3F700F30DB8 /* FCMManager.swift in Sources */,
 				8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */,
+				8FBD4E562B4AC05B00D32488 /* DefaultUserDetailRepository.swift in Sources */,
 				446B60F72B220D6000A361CB /* CameraButtonCell.swift in Sources */,
 				59E2C1602B248A6D004428F7 /* MyHiddenPostsViewController.swift in Sources */,
 				4416D48C2B174C7A0052BF33 /* KeychainManager.swift in Sources */,
@@ -1296,6 +1307,7 @@
 				59110EFB2B15F3D60009E9AC /* ChatRoomTableViewCell.swift in Sources */,
 				444A50942B0C8D1900454397 /* UIView+Divider.swift in Sources */,
 				59EA94BB2B359A23007EAA42 /* ReportRepository.swift in Sources */,
+				8FBD4E542B4AC04A00D32488 /* UserDetailRepository.swift in Sources */,
 				446B61142B275C2900A361CB /* PostNotificationPublisher.swift in Sources */,
 				8FBB65CE2B20C21100C6A133 /* GetChatListResponseDTO.swift in Sources */,
 				44A59F5E2B3BFC9C00736A34 /* DefaultPostListRepository.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -102,7 +102,7 @@
 		59EA94C52B35AAA7007EAA42 /* UseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59EA94C42B35AAA7007EAA42 /* UseCase.swift */; };
 		8F1B53322B0DE0D8006D8982 /* APIEndPoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1B53312B0DE0D8006D8982 /* APIEndPoints.swift */; };
 		8F1B53362B0E0396006D8982 /* PostListRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1B53352B0E0396006D8982 /* PostListRequestDTO.swift */; };
-		8F1E2CEE2B1F163D00179E34 /* GetRoomResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1E2CED2B1F163D00179E34 /* GetRoomResponseDTO.swift */; };
+		8F1E2CEE2B1F163D00179E34 /* ChatRoomResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F1E2CED2B1F163D00179E34 /* ChatRoomResponseDTO.swift */; };
 		8F3D79DD2B135D1500370536 /* ChatRoom.json in Resources */ = {isa = PBXBuildFile; fileRef = 8F3D79DC2B135D1500370536 /* ChatRoom.json */; };
 		8F3D79E02B136C6800370536 /* ChatRoomViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3D79DF2B136C6800370536 /* ChatRoomViewModel.swift */; };
 		8F3D79E22B14438A00370536 /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F3D79E12B14438A00370536 /* PostView.swift */; };
@@ -260,7 +260,7 @@
 		59EA94C42B35AAA7007EAA42 /* UseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCase.swift; sourceTree = "<group>"; };
 		8F1B53312B0DE0D8006D8982 /* APIEndPoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndPoints.swift; sourceTree = "<group>"; };
 		8F1B53352B0E0396006D8982 /* PostListRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListRequestDTO.swift; sourceTree = "<group>"; };
-		8F1E2CED2B1F163D00179E34 /* GetRoomResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetRoomResponseDTO.swift; sourceTree = "<group>"; };
+		8F1E2CED2B1F163D00179E34 /* ChatRoomResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomResponseDTO.swift; sourceTree = "<group>"; };
 		8F3D79DC2B135D1500370536 /* ChatRoom.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ChatRoom.json; sourceTree = "<group>"; };
 		8F3D79DF2B136C6800370536 /* ChatRoomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomViewModel.swift; sourceTree = "<group>"; };
 		8F3D79E12B14438A00370536 /* PostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostView.swift; sourceTree = "<group>"; };
@@ -501,7 +501,7 @@
 				44C1F5F22B0FF63C0047A436 /* PostResponseDTO.swift */,
 				8F8F0B922B1DC0C300BE97D2 /* PostRoomRequestDTO.swift */,
 				8F8F0B942B1DC0CE00BE97D2 /* PostRoomResponseDTO.swift */,
-				8F1E2CED2B1F163D00179E34 /* GetRoomResponseDTO.swift */,
+				8F1E2CED2B1F163D00179E34 /* ChatRoomResponseDTO.swift */,
 				8F8F0B842B1C7A5800BE97D2 /* ChatRoomRequestDTO.swift */,
 				8F8F0B8E2B1DB2EE00BE97D2 /* PostMuteResponseDTO.swift */,
 				8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */,
@@ -1242,7 +1242,7 @@
 				596AD1F22B259147005860B3 /* BlockedUsersViewModel.swift in Sources */,
 				59E2C1662B24B6D9004428F7 /* RequestFilterDTO.swift in Sources */,
 				44FC336B2B2A023C00FF4D65 /* NSItemProvider+.swift in Sources */,
-				8F1E2CEE2B1F163D00179E34 /* GetRoomResponseDTO.swift in Sources */,
+				8F1E2CEE2B1F163D00179E34 /* ChatRoomResponseDTO.swift in Sources */,
 				59E6A20F2B205C8500A2DF21 /* RequestPostSummaryView.swift in Sources */,
 				446B61002B2433E100A361CB /* ImageItem.swift in Sources */,
 				8F8F0B932B1DC0C300BE97D2 /* PostRoomRequestDTO.swift in Sources */,

--- a/iOS/Village/Village.xcodeproj/project.pbxproj
+++ b/iOS/Village/Village.xcodeproj/project.pbxproj
@@ -135,6 +135,9 @@
 		8FBB3BB92B26B431001876F5 /* GetAllReadResponseDTO .swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBB3BB82B26B431001876F5 /* GetAllReadResponseDTO .swift */; };
 		8FBB65CC2B20587B00C6A133 /* BlockedUserTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBB65CB2B20587B00C6A133 /* BlockedUserTableViewCell.swift */; };
 		8FBB65CE2B20C21100C6A133 /* GetChatListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */; };
+		8FBD4E482B4A745300D32488 /* DefaultChatRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E472B4A745300D32488 /* DefaultChatRoomRepository.swift */; };
+		8FBD4E4A2B4A746900D32488 /* ChatRoomRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E492B4A746900D32488 /* ChatRoomRepository.swift */; };
+		8FBD4E4C2B4A74A800D32488 /* ChatRoomUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBD4E4B2B4A74A800D32488 /* ChatRoomUseCase.swift */; };
 		8FBE3B0C2B048B1300660530 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B0B2B048B1300660530 /* HomeViewController.swift */; };
 		8FBE3B122B04CF6300660530 /* UILabel+SetTitle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B112B04CF6300660530 /* UILabel+SetTitle.swift */; };
 		8FBE3B142B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBE3B132B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift */; };
@@ -291,6 +294,9 @@
 		8FBB3BB82B26B431001876F5 /* GetAllReadResponseDTO .swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GetAllReadResponseDTO .swift"; sourceTree = "<group>"; };
 		8FBB65CB2B20587B00C6A133 /* BlockedUserTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockedUserTableViewCell.swift; sourceTree = "<group>"; };
 		8FBB65CD2B20C21100C6A133 /* GetChatListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetChatListResponseDTO.swift; sourceTree = "<group>"; };
+		8FBD4E472B4A745300D32488 /* DefaultChatRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChatRoomRepository.swift; sourceTree = "<group>"; };
+		8FBD4E492B4A746900D32488 /* ChatRoomRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomRepository.swift; sourceTree = "<group>"; };
+		8FBD4E4B2B4A74A800D32488 /* ChatRoomUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRoomUseCase.swift; sourceTree = "<group>"; };
 		8FBE3B0B2B048B1300660530 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		8FBE3B112B04CF6300660530 /* UILabel+SetTitle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+SetTitle.swift"; sourceTree = "<group>"; };
 		8FBE3B132B04D84B00660530 /* UINavigationItem+MakeSFSymbolButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationItem+MakeSFSymbolButton.swift"; sourceTree = "<group>"; };
@@ -725,6 +731,7 @@
 			children = (
 				59EA94BA2B359A23007EAA42 /* ReportRepository.swift */,
 				44A59F5B2B3BFC7700736A34 /* PostListRepository.swift */,
+				8FBD4E492B4A746900D32488 /* ChatRoomRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -735,6 +742,7 @@
 				44A59F582B3BFC1500736A34 /* Protocol */,
 				59EA94C22B35A331007EAA42 /* ReportUseCase.swift */,
 				44A59F592B3BFC4A00736A34 /* PostListUseCase.swift */,
+				8FBD4E4B2B4A74A800D32488 /* ChatRoomUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -744,6 +752,7 @@
 			children = (
 				59EA94C02B359ABB007EAA42 /* DefaultReportRepository.swift */,
 				44A59F5D2B3BFC9C00736A34 /* DefaultPostListRepository.swift */,
+				8FBD4E472B4A745300D32488 /* DefaultChatRoomRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -1247,6 +1256,7 @@
 				5980D75F2B0FB6DB00A6B370 /* PostCreateRepository.swift in Sources */,
 				4416D48E2B174CBA0052BF33 /* KeychainError.swift in Sources */,
 				4491AA282B05D6C90016FC70 /* MenuView.swift in Sources */,
+				8FBD4E482B4A745300D32488 /* DefaultChatRoomRepository.swift in Sources */,
 				8F95CF982B0C7B270024631F /* Responsable.swift in Sources */,
 				44A59F5C2B3BFC7700736A34 /* PostListRepository.swift in Sources */,
 				8F97D06C2B222EFA00A19754 /* OpponentChatTableViewCell.swift in Sources */,
@@ -1313,6 +1323,7 @@
 				8F8F0B8B2B1D985A00BE97D2 /* BlockedUserViewController.swift in Sources */,
 				8F8F0B8D2B1DA91500BE97D2 /* HiddenRentPostTableViewCell.swift in Sources */,
 				59AADE382B22086400C3E17D /* EditProfileViewModel.swift in Sources */,
+				8FBD4E4A2B4A746900D32488 /* ChatRoomRepository.swift in Sources */,
 				44FC33692B2986E900FF4D65 /* ImageDetailView.swift in Sources */,
 				8FBB65CC2B20587B00C6A133 /* BlockedUserTableViewCell.swift in Sources */,
 				59A384642B26093600660B70 /* ReportViewModel.swift in Sources */,
@@ -1341,6 +1352,7 @@
 				8FC7FE742B05CE9A00B91D3B /* HomeViewModel.swift in Sources */,
 				5900F92C2B2AD70C0065B7F6 /* ProfileTableViewCell.swift in Sources */,
 				44C1F5E62B0FE37C0047A436 /* PostDetailViewModel.swift in Sources */,
+				8FBD4E4C2B4A74A800D32488 /* ChatRoomUseCase.swift in Sources */,
 				8FC7FE7B2B07A89A00B91D3B /* PostDetailViewController.swift in Sources */,
 				4416D4552B14B5F00052BF33 /* NicknameTextField.swift in Sources */,
 				8FF7E60D2B0F38A500B6D678 /* ChatListViewController.swift in Sources */,

--- a/iOS/Village/Village/Data/Network/APIEndPoints.swift
+++ b/iOS/Village/Village/Data/Network/APIEndPoints.swift
@@ -118,7 +118,7 @@ struct APIEndPoints {
         )
     }
     
-    static func getChatRoom(with roomID: Int) -> EndPoint<GetRoomResponseDTO> {
+    static func getChatRoom(with roomID: Int) -> EndPoint<ChatRoomResponseDTO> {
         return EndPoint(
             baseURL: baseURL,
             path: "chat/room/\(roomID)",

--- a/iOS/Village/Village/Data/Network/DTO/ChatDTO.swift
+++ b/iOS/Village/Village/Data/Network/DTO/ChatDTO.swift
@@ -1,0 +1,48 @@
+//
+//  ChatDTO.swift
+//  Village
+//
+//  Created by 박동재 on 1/10/24.
+//
+
+import Foundation
+
+struct ChatDTO: Hashable, Codable {
+    
+    let id: Int
+    let message: String
+    let sender: String
+    let chatRoom: Int
+    let isRead: Bool
+    let createDate: String
+    let deleteDate: String?
+    let count: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case message
+        case sender
+        case chatRoom = "chat_room"
+        case isRead = "is_read"
+        case createDate = "create_date"
+        case deleteDate = "delete_date"
+        case count
+    }
+    
+}
+
+extension ChatDTO {
+    
+    func toDomain() -> Chat {
+        .init(
+            id: self.id,
+            message: self.message,
+            sender: self.sender,
+            chatRoom: self.chatRoom,
+            isRead: self.isRead,
+            createDate: self.createDate,
+            deleteDate: self.deleteDate,
+            count: self.count)
+    }
+    
+}

--- a/iOS/Village/Village/Data/Network/DTO/ChatRoomResponseDTO.swift
+++ b/iOS/Village/Village/Data/Network/DTO/ChatRoomResponseDTO.swift
@@ -7,30 +7,6 @@
 
 import Foundation
 
-struct Chat: Hashable, Codable {
-    
-    let id: Int
-    let message: String
-    let sender: String
-    let chatRoom: Int
-    let isRead: Bool
-    let createDate: String
-    let deleteDate: String?
-    let count: Int
-    
-    enum CodingKeys: String, CodingKey {
-        case id
-        case message
-        case sender
-        case chatRoom = "chat_room"
-        case isRead = "is_read"
-        case createDate = "create_date"
-        case deleteDate = "delete_date"
-        case count
-    }
-    
-}
-
 struct ChatRoomResponseDTO: Codable {
     
     let writer: String
@@ -38,7 +14,7 @@ struct ChatRoomResponseDTO: Codable {
     let user: String
     let userProfileIMG: String
     let postID: Int
-    let chatLog: [Chat]
+    let chatLog: [ChatDTO]
     
     enum CodingKeys: String, CodingKey {
         case writer
@@ -47,6 +23,21 @@ struct ChatRoomResponseDTO: Codable {
         case userProfileIMG = "user_profile_img"
         case postID = "post_id"
         case chatLog = "chat_log"
+    }
+    
+}
+
+extension ChatRoomResponseDTO {
+    
+    func toDomain() -> ChatRoom {
+        .init(
+            writer: self.writer,
+            writerProfileIMG: self.writerProfileIMG,
+            user: self.user,
+            userProfileIMG: self.userProfileIMG,
+            postID: self.postID,
+            chatLog: self.chatLog.map { $0.toDomain() }
+        )
     }
     
 }

--- a/iOS/Village/Village/Data/Network/DTO/ChatRoomResponseDTO.swift
+++ b/iOS/Village/Village/Data/Network/DTO/ChatRoomResponseDTO.swift
@@ -1,5 +1,5 @@
 //
-//  GetRoomResponseDTO.swift
+//  ChatRoomResponseDTO.swift
 //  Village
 //
 //  Created by 박동재 on 2023/12/05.
@@ -31,7 +31,7 @@ struct Chat: Hashable, Codable {
     
 }
 
-struct GetRoomResponseDTO: Codable {
+struct ChatRoomResponseDTO: Codable {
     
     let writer: String
     let writerProfileIMG: String

--- a/iOS/Village/Village/Data/Network/DTO/UserResponseDTO.swift
+++ b/iOS/Village/Village/Data/Network/DTO/UserResponseDTO.swift
@@ -18,3 +18,14 @@ struct UserResponseDTO: Hashable, Decodable {
     }
     
 }
+
+extension UserResponseDTO {
+    
+    func toDomain() -> UserDetail {
+        .init(
+            nickname: self.nickname,
+            profileImageURL: self.profileImageURL
+        )
+    }
+    
+}

--- a/iOS/Village/Village/Data/Repository/DefaultChatRoomRepository.swift
+++ b/iOS/Village/Village/Data/Repository/DefaultChatRoomRepository.swift
@@ -1,0 +1,39 @@
+//
+//  DefaultChatRoomRepository.swift
+//  Village
+//
+//  Created by 박동재 on 1/7/24.
+//
+
+import Foundation
+
+struct DefaultChatRoomRepository: ChatRoomRepository {
+    
+    typealias ResponseDTO = ChatRoomResponseDTO
+    
+    private func makeEndPoint(roomID: Int) -> EndPoint<ChatRoomResponseDTO  > {
+        return EndPoint(
+            baseURL: Constant.baseURL,
+            path: "chat/room/\(roomID)",
+            method: .GET
+        )
+    }
+    
+    func fetchRoomData(roomID: Int) async -> Result<ChatRoomResponseDTO, NetworkError> {
+        let endpoint = makeEndPoint(roomID: roomID)
+        
+        do {
+            guard let roomDataDTO = try await APIProvider.shared.request(with: endpoint) else {
+                return .success(
+                    ResponseDTO(writer: "", writerProfileIMG: "", user: "", userProfileIMG: "", postID: -1, chatLog: [])
+                )
+            }
+            return .success(roomDataDTO)
+        } catch let error as NetworkError {
+            return .failure(error)
+        } catch {
+            return .failure(.unknownError)
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Data/Repository/DefaultChatRoomRepository.swift
+++ b/iOS/Village/Village/Data/Repository/DefaultChatRoomRepository.swift
@@ -24,9 +24,7 @@ struct DefaultChatRoomRepository: ChatRoomRepository {
         
         do {
             guard let roomDataDTO = try await APIProvider.shared.request(with: endpoint) else {
-                return .success(
-                    ResponseDTO(writer: "", writerProfileIMG: "", user: "", userProfileIMG: "", postID: -1, chatLog: [])
-                )
+                return .failure(.emptyData)
             }
             return .success(roomDataDTO)
         } catch let error as NetworkError {

--- a/iOS/Village/Village/Data/Repository/DefaultPostDetailRepostory.swift
+++ b/iOS/Village/Village/Data/Repository/DefaultPostDetailRepostory.swift
@@ -1,0 +1,37 @@
+//
+//  DefaultPostDetailRepostory.swift
+//  Village
+//
+//  Created by 박동재 on 1/7/24.
+//
+
+import Foundation
+
+struct DefaultPostDetailRepostory: PostDetailRepository {
+    
+    typealias ResponseDTO = PostResponseDTO
+    
+    private func makeEndPoint(postID: Int) -> EndPoint<PostResponseDTO> {
+        return EndPoint(
+            baseURL: Constant.baseURL,
+            path: "posts/\(postID)",
+            method: .GET
+        )
+    }
+    
+    func fetchPostData(postID: Int) async -> Result<PostResponseDTO, NetworkError> {
+        let endpoint = makeEndPoint(postID: postID)
+        
+        do {
+            guard let responseDTO = try await APIProvider.shared.request(with: endpoint) else {
+                return .failure(.emptyData)
+            }
+            return .success(responseDTO)
+        } catch let error as NetworkError {
+            return .failure(error)
+        } catch {
+            return .failure(.unknownError)
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Data/Repository/DefaultPostDetailRepostory.swift
+++ b/iOS/Village/Village/Data/Repository/DefaultPostDetailRepostory.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 struct DefaultPostDetailRepostory: PostDetailRepository {
     
@@ -19,19 +20,12 @@ struct DefaultPostDetailRepostory: PostDetailRepository {
         )
     }
     
-    func fetchPostData(postID: Int) async -> Result<PostResponseDTO, NetworkError> {
+    func fetchPostData(postID: Int) -> AnyPublisher<PostDetail, NetworkError> {
         let endpoint = makeEndPoint(postID: postID)
         
-        do {
-            guard let responseDTO = try await APIProvider.shared.request(with: endpoint) else {
-                return .failure(.emptyData)
-            }
-            return .success(responseDTO)
-        } catch let error as NetworkError {
-            return .failure(error)
-        } catch {
-            return .failure(.unknownError)
-        }
+        return NetworkService.shared.request(endpoint)
+            .map { $0.toDomain() }
+            .eraseToAnyPublisher()
     }
     
 }

--- a/iOS/Village/Village/Data/Repository/DefaultReportRepository.swift
+++ b/iOS/Village/Village/Data/Repository/DefaultReportRepository.swift
@@ -34,21 +34,14 @@ struct DefaultReportRepository: ReportRepository {
         postID: Int,
         userID: String,
         description: String
-    ) async -> Result<Void, NetworkError> {
+    ) -> AnyPublisher<Void, NetworkError> {
         let endpoint = makeReportUserEndpoint(
             postID: postID,
             userID: userID,
             description: description
         )
         
-        do {
-            try await APIProvider.shared.request(with: endpoint)
-            return .success(())
-        } catch let error as NetworkError {
-            return .failure(error)
-        } catch {
-            return .failure(.unknownError)
-        }
+        return NetworkService.shared.request(endpoint)
     }
     
 }

--- a/iOS/Village/Village/Data/Repository/DefaultUserDetailRepository.swift
+++ b/iOS/Village/Village/Data/Repository/DefaultUserDetailRepository.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 struct DefaultUserDetailRepository: UserDetailRepository {
     
@@ -19,19 +20,12 @@ struct DefaultUserDetailRepository: UserDetailRepository {
         )
     }
     
-    func fetchUserData(userID: String) async -> Result<UserResponseDTO, NetworkError> {
+    func fetchUserData(userID: String) -> AnyPublisher<UserDetail, NetworkError> {
         let endpoint = makeEndPoint(userID: userID)
         
-        do {
-            guard let responseDTO = try await APIProvider.shared.request(with: endpoint) else {
-                return .failure(.emptyData)
-            }
-            return .success(responseDTO)
-        } catch let error as NetworkError {
-            return .failure(error)
-        } catch {
-            return .failure(.unknownError)
-        }
+        return NetworkService.shared.request(endpoint)
+            .map { $0.toDomain() }
+            .eraseToAnyPublisher()
     }
     
 }

--- a/iOS/Village/Village/Data/Repository/DefaultUserDetailRepository.swift
+++ b/iOS/Village/Village/Data/Repository/DefaultUserDetailRepository.swift
@@ -1,0 +1,37 @@
+//
+//  DefaultUserDetailRepository.swift
+//  Village
+//
+//  Created by 박동재 on 1/7/24.
+//
+
+import Foundation
+
+struct DefaultUserDetailRepository: UserDetailRepository {
+    
+    typealias ResponseDTO = UserResponseDTO
+    
+    private func makeEndPoint(userID: String) -> EndPoint<UserResponseDTO> {
+        return EndPoint(
+            baseURL: Constant.baseURL,
+            path: "users/\(userID)",
+            method: .GET
+        )
+    }
+    
+    func fetchUserData(userID: String) async -> Result<UserResponseDTO, NetworkError> {
+        let endpoint = makeEndPoint(userID: userID)
+        
+        do {
+            guard let responseDTO = try await APIProvider.shared.request(with: endpoint) else {
+                return .failure(.emptyData)
+            }
+            return .success(responseDTO)
+        } catch let error as NetworkError {
+            return .failure(error)
+        } catch {
+            return .failure(.unknownError)
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Domain/Entity/ChatRoomData.swift
+++ b/iOS/Village/Village/Domain/Entity/ChatRoomData.swift
@@ -1,0 +1,52 @@
+//
+//  ChatRoomData.swift
+//  Village
+//
+//  Created by 박동재 on 1/10/24.
+//
+
+import Foundation
+
+struct Chat: Hashable, Codable {
+    
+    let id: Int
+    let message: String
+    let sender: String
+    let chatRoom: Int
+    let isRead: Bool
+    let createDate: String
+    let deleteDate: String?
+    let count: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case message
+        case sender
+        case chatRoom = "chat_room"
+        case isRead = "is_read"
+        case createDate = "create_date"
+        case deleteDate = "delete_date"
+        case count
+    }
+    
+}
+
+struct ChatRoom: Codable {
+    
+    let writer: String
+    let writerProfileIMG: String
+    let user: String
+    let userProfileIMG: String
+    let postID: Int
+    let chatLog: [Chat]
+    
+    enum CodingKeys: String, CodingKey {
+        case writer
+        case writerProfileIMG = "writer_profile_img"
+        case user
+        case userProfileIMG = "user_profile_img"
+        case postID = "post_id"
+        case chatLog = "chat_log"
+    }
+    
+}

--- a/iOS/Village/Village/Domain/Entity/PostDetail.swift
+++ b/iOS/Village/Village/Domain/Entity/PostDetail.swift
@@ -1,13 +1,13 @@
 //
-//  PostResponseDTO.swift
+//  PostDetail.swift
 //  Village
 //
-//  Created by 정상윤 on 11/24/23.
+//  Created by 박동재 on 1/11/24.
 //
 
 import Foundation
 
-struct PostResponseDTO: Decodable {
+struct PostDetail: Decodable {
     
     let title: String
     let description: String
@@ -33,7 +33,7 @@ struct PostResponseDTO: Decodable {
     
 }
 
-extension PostResponseDTO: Hashable {
+extension PostDetail: Hashable {
     
     func hash(into hasher: inout Hasher) {
         hasher.combine(postID)
@@ -41,24 +41,6 @@ extension PostResponseDTO: Hashable {
     
     static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.postID == rhs.postID
-    }
-    
-}
-
-extension PostResponseDTO {
-    
-    func toDomain() -> PostDetail {
-        .init(
-            title: self.title,
-            description: self.description,
-            price: self.price,
-            postID: self.postID,
-            userID: self.userID,
-            images: self.images,
-            isRequest: self.isRequest,
-            startDate: self.startDate,
-            endDate: self.endDate
-        )
     }
     
 }

--- a/iOS/Village/Village/Domain/Entity/UserDetail.swift
+++ b/iOS/Village/Village/Domain/Entity/UserDetail.swift
@@ -1,0 +1,20 @@
+//
+//  UserDetail.swift
+//  Village
+//
+//  Created by 박동재 on 1/11/24.
+//
+
+import Foundation
+
+struct UserDetail: Hashable, Decodable {
+    
+    let nickname: String
+    let profileImageURL: String
+    
+    enum CodingKeys: String, CodingKey {
+        case nickname
+        case profileImageURL = "profile_img"
+    }
+    
+}

--- a/iOS/Village/Village/Domain/Repository/ChatRoomRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/ChatRoomRepository.swift
@@ -10,8 +10,6 @@ import Combine
 
 protocol ChatRoomRepository {
     
-    associatedtype ResponseDTO
-    
     func fetchRoomData(roomID: Int) -> AnyPublisher<ChatRoom, NetworkError>
     
 }

--- a/iOS/Village/Village/Domain/Repository/ChatRoomRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/ChatRoomRepository.swift
@@ -1,0 +1,16 @@
+//
+//  ChatRoomRepository.swift
+//  Village
+//
+//  Created by 박동재 on 1/7/24.
+//
+
+import Foundation
+
+protocol ChatRoomRepository {
+    
+    associatedtype ResponseDTO
+    
+    func fetchRoomData(roomID: Int) async -> Result<ChatRoomResponseDTO, NetworkError>
+    
+}

--- a/iOS/Village/Village/Domain/Repository/ChatRoomRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/ChatRoomRepository.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
+import Combine
 
 protocol ChatRoomRepository {
     
     associatedtype ResponseDTO
     
-    func fetchRoomData(roomID: Int) async -> Result<ChatRoomResponseDTO, NetworkError>
+    func fetchRoomData(roomID: Int) -> AnyPublisher<ChatRoom, NetworkError>
     
 }

--- a/iOS/Village/Village/Domain/Repository/PostDetailRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/PostDetailRepository.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
+import Combine
 
 protocol PostDetailRepository {
     
     associatedtype ResponseDTO
     
-    func fetchPostData(postID: Int) async -> Result<PostResponseDTO, NetworkError>
+    func fetchPostData(postID: Int) -> AnyPublisher<PostDetail, NetworkError>
     
 }

--- a/iOS/Village/Village/Domain/Repository/PostDetailRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/PostDetailRepository.swift
@@ -10,8 +10,6 @@ import Combine
 
 protocol PostDetailRepository {
     
-    associatedtype ResponseDTO
-    
     func fetchPostData(postID: Int) -> AnyPublisher<PostDetail, NetworkError>
     
 }

--- a/iOS/Village/Village/Domain/Repository/PostDetailRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/PostDetailRepository.swift
@@ -1,0 +1,16 @@
+//
+//  PostDetailRepository.swift
+//  Village
+//
+//  Created by 박동재 on 1/7/24.
+//
+
+import Foundation
+
+protocol PostDetailRepository {
+    
+    associatedtype ResponseDTO
+    
+    func fetchPostData(postID: Int) async -> Result<PostResponseDTO, NetworkError>
+    
+}

--- a/iOS/Village/Village/Domain/Repository/PostListRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/PostListRepository.swift
@@ -10,9 +10,6 @@ import Combine
 
 protocol PostListRepository {
     
-    associatedtype RequestDTO
-    associatedtype ResponseDTO
-    
     func fetchPostList(
         searchKeyword: String?,
         postType: PostType,

--- a/iOS/Village/Village/Domain/Repository/PostListRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/PostListRepository.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 protocol PostListRepository {
     
@@ -17,6 +18,6 @@ protocol PostListRepository {
         postType: PostType,
         writer: String?,
         lastID: String?
-    ) async -> Result<[PostListItem], Error>
+    ) -> AnyPublisher<[PostListItem], NetworkError>
     
 }

--- a/iOS/Village/Village/Domain/Repository/ReportRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/ReportRepository.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 protocol ReportRepository {
     
@@ -13,6 +14,6 @@ protocol ReportRepository {
         postID: Int,
         userID: String,
         description: String
-    ) async -> Result<Void, NetworkError>
+    ) -> AnyPublisher<Void, NetworkError>
     
 }

--- a/iOS/Village/Village/Domain/Repository/UserDetailRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/UserDetailRepository.swift
@@ -1,0 +1,16 @@
+//
+//  UserDetailRepository.swift
+//  Village
+//
+//  Created by 박동재 on 1/7/24.
+//
+
+import Foundation
+
+protocol UserDetailRepository {
+    
+    associatedtype ResponseDTO
+    
+    func fetchUserData(userID: String) async -> Result<UserResponseDTO, NetworkError>
+    
+}

--- a/iOS/Village/Village/Domain/Repository/UserDetailRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/UserDetailRepository.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
+import Combine
 
 protocol UserDetailRepository {
     
     associatedtype ResponseDTO
     
-    func fetchUserData(userID: String) async -> Result<UserResponseDTO, NetworkError>
+    func fetchUserData(userID: String) -> AnyPublisher<UserDetail, NetworkError>
     
 }

--- a/iOS/Village/Village/Domain/Repository/UserDetailRepository.swift
+++ b/iOS/Village/Village/Domain/Repository/UserDetailRepository.swift
@@ -10,8 +10,6 @@ import Combine
 
 protocol UserDetailRepository {
     
-    associatedtype ResponseDTO
-    
     func fetchUserData(userID: String) -> AnyPublisher<UserDetail, NetworkError>
     
 }

--- a/iOS/Village/Village/Domain/UseCase/ChatRoomUseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/ChatRoomUseCase.swift
@@ -1,0 +1,32 @@
+//
+//  ChatRoomUseCase.swift
+//  Village
+//
+//  Created by 박동재 on 1/7/24.
+//
+
+import Foundation
+
+struct ChatRoomUseCase: UseCase {
+    
+    private let repository: DefaultChatRoomRepository
+    private let roomID: Int
+    private let completion: (Result<ChatRoomResponseDTO, NetworkError>) -> Void
+    
+    init(repository: DefaultChatRoomRepository,
+         roomID: Int,
+         completion: @escaping (Result<ChatRoomResponseDTO, NetworkError>) -> Void
+    ) {
+        self.repository = repository
+        self.roomID = roomID
+        self.completion = completion
+    }
+    
+    func start() {
+        Task {
+            let result = await repository.fetchRoomData(roomID: roomID)
+            completion(result)
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Domain/UseCase/ChatRoomUseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/ChatRoomUseCase.swift
@@ -6,27 +6,26 @@
 //
 
 import Foundation
+import Combine
 
 struct ChatRoomUseCase: UseCase {
     
+    typealias ResultValue = ChatRoom
+    
     private let repository: DefaultChatRoomRepository
     private let roomID: Int
-    private let completion: (Result<ChatRoomResponseDTO, NetworkError>) -> Void
     
     init(repository: DefaultChatRoomRepository,
-         roomID: Int,
-         completion: @escaping (Result<ChatRoomResponseDTO, NetworkError>) -> Void
+         roomID: Int
     ) {
         self.repository = repository
         self.roomID = roomID
-        self.completion = completion
     }
     
-    func start() {
-        Task {
-            let result = await repository.fetchRoomData(roomID: roomID)
-            completion(result)
-        }
+    func start() -> AnyPublisher<ResultValue, NetworkError> {
+        repository
+            .fetchRoomData(roomID: roomID)
+            .eraseToAnyPublisher()
     }
     
 }

--- a/iOS/Village/Village/Domain/UseCase/PostDetailUseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/PostDetailUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  PostDetailUseCase.swift
+//  Village
+//
+//  Created by 박동재 on 1/7/24.
+//
+
+import Foundation
+
+struct PostDetailUseCase: UseCase {
+    
+    private let repository: DefaultPostDetailRepostory
+    private let postID: Int
+    private let completion: (Result<PostResponseDTO, NetworkError>) -> Void
+
+    init(
+        repository: DefaultPostDetailRepostory,
+        postID: Int,
+        completion: @escaping (Result<PostResponseDTO, NetworkError>) -> Void
+    ) {
+        self.repository = repository
+        self.postID = postID
+        self.completion = completion
+    }
+    
+    func start() {
+        Task {
+            let result = await repository.fetchPostData(postID: postID)
+            completion(result)
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Domain/UseCase/PostDetailUseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/PostDetailUseCase.swift
@@ -6,28 +6,27 @@
 //
 
 import Foundation
+import Combine
 
 struct PostDetailUseCase: UseCase {
     
+    typealias ResultValue = PostDetail
+    
     private let repository: DefaultPostDetailRepostory
     private let postID: Int
-    private let completion: (Result<PostResponseDTO, NetworkError>) -> Void
 
     init(
         repository: DefaultPostDetailRepostory,
-        postID: Int,
-        completion: @escaping (Result<PostResponseDTO, NetworkError>) -> Void
+        postID: Int
     ) {
         self.repository = repository
         self.postID = postID
-        self.completion = completion
     }
     
-    func start() {
-        Task {
-            let result = await repository.fetchPostData(postID: postID)
-            completion(result)
-        }
+    func start() -> AnyPublisher<ResultValue, NetworkError> {
+        repository
+            .fetchPostData(postID: postID)
+            .eraseToAnyPublisher()
     }
     
 }

--- a/iOS/Village/Village/Domain/UseCase/PostListUseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/PostListUseCase.swift
@@ -10,6 +10,8 @@ import Combine
 
 struct PostListUseCase: UseCase {
     
+    typealias ResultValue = PostListItem
+    
     struct RequestValue {
         let searchKeyword: String? = nil
         let postType: PostType
@@ -19,27 +21,21 @@ struct PostListUseCase: UseCase {
     
     private let repository: DefaultPostListRepository
     private let requestValue: RequestValue
-    private let completion: (Result<[PostListItem], Error>) -> Void
     
     init(repository: DefaultPostListRepository,
-         requestValue: RequestValue,
-         completion: @escaping (Result<[PostListItem], Error>) -> Void
+         requestValue: RequestValue
     ) {
         self.repository = repository
         self.requestValue = requestValue
-        self.completion = completion
     }
     
-    func start() {
-        Task {
-            let result = await repository.fetchPostList(
-                searchKeyword: requestValue.searchKeyword,
-                postType: requestValue.postType,
-                writer: requestValue.writer,
-                lastID: requestValue.lastID
-            )
-            completion(result)
-        }
+    func start() -> AnyPublisher<[ResultValue], NetworkError> {
+        return repository.fetchPostList(
+            searchKeyword: requestValue.searchKeyword,
+            postType: requestValue.postType,
+            writer: requestValue.writer,
+            lastID: requestValue.lastID)
+        .eraseToAnyPublisher()
     }
     
 }

--- a/iOS/Village/Village/Domain/UseCase/PostListUseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/PostListUseCase.swift
@@ -10,7 +10,7 @@ import Combine
 
 struct PostListUseCase: UseCase {
     
-    typealias ResultValue = PostListItem
+    typealias ResultValue = [PostListItem]
     
     struct RequestValue {
         let searchKeyword: String? = nil
@@ -29,13 +29,14 @@ struct PostListUseCase: UseCase {
         self.requestValue = requestValue
     }
     
-    func start() -> AnyPublisher<[ResultValue], NetworkError> {
-        return repository.fetchPostList(
-            searchKeyword: requestValue.searchKeyword,
-            postType: requestValue.postType,
-            writer: requestValue.writer,
-            lastID: requestValue.lastID)
-        .eraseToAnyPublisher()
+    func start() -> AnyPublisher<ResultValue, NetworkError> {
+        repository
+            .fetchPostList(
+                searchKeyword: requestValue.searchKeyword,
+                postType: requestValue.postType,
+                writer: requestValue.writer,
+                lastID: requestValue.lastID)
+            .eraseToAnyPublisher()
     }
     
 }

--- a/iOS/Village/Village/Domain/UseCase/Protocol/UseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/Protocol/UseCase.swift
@@ -6,9 +6,12 @@
 //
 
 import Foundation
+import Combine
 
 protocol UseCase {
     
-    func start()
+    associatedtype ResultValue
+    
+    func start() -> AnyPublisher<ResultValue, NetworkError>
     
 }

--- a/iOS/Village/Village/Domain/UseCase/ReportUseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/ReportUseCase.swift
@@ -8,7 +8,9 @@
 import Foundation
 import Combine
 
-struct ReportUseCase {
+struct ReportUseCase: UseCase {
+    
+    typealias ResultValue = Void
     
     struct RequestValue {
         let postID: Int
@@ -18,32 +20,22 @@ struct ReportUseCase {
     
     private let repository: DefaultReportRepository
     private let requestValue: RequestValue
-    private let completeOutput: PassthroughSubject<Void, Error>
     
     init(
         repository: DefaultReportRepository,
-        requestValue: RequestValue,
-        completeOutput: PassthroughSubject<Void, Error>
+        requestValue: RequestValue
     ) {
         self.repository = repository
         self.requestValue = requestValue
-        self.completeOutput = completeOutput
     }
     
-    func start() {
-        Task {
-            let result = await self.repository.reportUser(
-                postID: requestValue.postID,
-                userID: requestValue.userID,
-                description: requestValue.description
-            )
-            switch result {
-            case .success(let success):
-                completeOutput.send()
-            case .failure(let error):
-                completeOutput.send(completion: .failure(error))
-            }
-        }
+    func start() -> AnyPublisher<ResultValue, NetworkError> {
+        repository.reportUser(
+            postID: requestValue.postID,
+            userID: requestValue.userID,
+            description: requestValue.description
+        )
+        .eraseToAnyPublisher()
     }
     
 }

--- a/iOS/Village/Village/Domain/UseCase/UserDetailUseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/UserDetailUseCase.swift
@@ -1,0 +1,33 @@
+//
+//  UserDetailUseCase.swift
+//  Village
+//
+//  Created by 박동재 on 1/7/24.
+//
+
+import Foundation
+
+struct UserDetailUseCase: UseCase {
+    
+    private let repository: DefaultUserDetailRepository
+    private let userID: String
+    private let completion: (Result<UserResponseDTO, NetworkError>) -> Void
+    
+    init(
+        repository: DefaultUserDetailRepository,
+        userID: String,
+        completion: @escaping (Result<UserResponseDTO, NetworkError>) -> Void
+    ) {
+        self.repository = repository
+        self.userID = userID
+        self.completion = completion
+    }
+    
+    func start() {
+        Task {
+            let result = await repository.fetchUserData(userID: userID)
+            completion(result)
+        }
+    }
+    
+}

--- a/iOS/Village/Village/Domain/UseCase/UserDetailUseCase.swift
+++ b/iOS/Village/Village/Domain/UseCase/UserDetailUseCase.swift
@@ -6,28 +6,27 @@
 //
 
 import Foundation
+import Combine
 
 struct UserDetailUseCase: UseCase {
     
+    typealias ResultValue = UserDetail
+    
     private let repository: DefaultUserDetailRepository
     private let userID: String
-    private let completion: (Result<UserResponseDTO, NetworkError>) -> Void
     
     init(
         repository: DefaultUserDetailRepository,
-        userID: String,
-        completion: @escaping (Result<UserResponseDTO, NetworkError>) -> Void
+        userID: String
     ) {
         self.repository = repository
         self.userID = userID
-        self.completion = completion
     }
     
-    func start() {
-        Task {
-            let result = await repository.fetchUserData(userID: userID)
-            completion(result)
-        }
+    func start() -> AnyPublisher<ResultValue, NetworkError> {
+        repository
+            .fetchUserData(userID: userID)
+            .eraseToAnyPublisher()
     }
     
 }

--- a/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/View/ChatRoomViewController.swift
@@ -318,7 +318,7 @@ private extension ChatRoomViewController {
         navigationItem.backButtonDisplayMode = .minimal
     }
     
-    func setNavigationTitle(user: UserResponseDTO) {
+    func setNavigationTitle(user: UserDetail) {
         self.navigationItem.title = user.nickname
     }
     
@@ -442,7 +442,7 @@ private extension ChatRoomViewController {
             .store(in: &cancellableBag)
     }
     
-    func setPostContent(post: PostResponseDTO) {
+    func setPostContent(post: PostDetail) {
         if post.isRequest == true {
             view.addSubview(self.requestPostView)
             NSLayoutConstraint.activate([

--- a/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -27,8 +27,8 @@ final class ChatRoomViewModel {
     private let roomIDOutput = PassthroughSubject<Int, Never>()
     private let joinOutput = PassthroughSubject<Int, Never>()
     private let postIDOutput = PassthroughSubject<Int, Never>()
-    private let postOutput = PassthroughSubject<PostResponseDTO, NetworkError>()
-    private let userOutput = PassthroughSubject<UserResponseDTO, NetworkError>()
+    private let postOutput = PassthroughSubject<PostDetail, NetworkError>()
+    private let userOutput = PassthroughSubject<UserDetail, NetworkError>()
     private let reportOutput = PassthroughSubject<(postID: Int, userID: String), Never>()
     private let popViewControllerOutput = PassthroughSubject<Void, NetworkError>()
     private let tableViewReloadOutput = PassthroughSubject<Void, Never>()
@@ -251,8 +251,8 @@ extension ChatRoomViewModel {
         let joinOutput: AnyPublisher<Int, Never>
         let roomIDOutput: AnyPublisher<Int, Never>
         let postIDOutput: AnyPublisher<Int, Never>
-        let postOutput: AnyPublisher<PostResponseDTO, NetworkError>
-        let userOutput: AnyPublisher<UserResponseDTO, NetworkError>
+        let postOutput: AnyPublisher<PostDetail, NetworkError>
+        let userOutput: AnyPublisher<UserDetail, NetworkError>
         let reportOutput: AnyPublisher<(postID: Int, userID: String), Never>
         let popViewControllerOutput: AnyPublisher<Void, NetworkError>
         let tableViewReloadOutput: AnyPublisher<Void, Never>

--- a/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -103,7 +103,24 @@ final class ChatRoomViewModel {
     }
     
     private func setRoom(data: ChatRoom) {
-        
+        data.chatLog.forEach { [weak self] chat in
+            self?.appendLog(sender: chat.sender, message: chat.message)
+        }
+        if postID != data.postID {
+            postID = data.postID
+            if checkUser(userID: data.user) {
+                userID = data.writer
+                myProfileURL = data.userProfileIMG
+                opponentProfileURL = data.writerProfileIMG
+            } else {
+                userID = data.user
+                myProfileURL = data.writerProfileIMG
+                opponentProfileURL = data.userProfileIMG
+            }
+            getPostData()
+            getUserData()
+            getImageData()
+        }
     }
     
     func getChatRoomData() {
@@ -124,39 +141,6 @@ final class ChatRoomViewModel {
         }
         .store(in: &cancellableBag)
     }
-    
-//    func getChatRoomData() {
-//        ChatRoomUseCase(
-//            repository: DefaultChatRoomRepository(),
-//            roomID: self.roomID
-//        ) { [weak self] result in
-//            switch result {
-//            case .success(let data):
-//                guard let self = self else { return }
-//                data.chatLog.forEach { [weak self] chat in
-//                    self?.appendLog(sender: chat.sender, message: chat.message)
-//                }
-//                if self.postID != data.postID {
-//                    self.postID = data.postID
-//                    if checkUser(userID: data.user) {
-//                        self.userID = data.writer
-//                        self.myProfileURL = data.userProfileIMG
-//                        self.opponentProfileURL = data.writerProfileIMG
-//                    } else {
-//                        self.userID = data.user
-//                        self.myProfileURL = data.writerProfileIMG
-//                        self.opponentProfileURL = data.userProfileIMG
-//                    }
-//                    self.getPostData()
-//                    self.getUserData()
-//                    self.getImageData()
-//                }
-//            case .failure(let error):
-//                dump(error)
-//            }
-//        }
-//        .start()
-//    }
     
     func getPostData() {
         PostDetailUseCase(

--- a/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -146,30 +146,39 @@ final class ChatRoomViewModel {
         PostDetailUseCase(
             repository: DefaultPostDetailRepostory(),
             postID: self.postID
-        ) { [weak self] result in
-            switch result {
-            case .success(let post):
-                self?.postOutput.send(post)
-            case .failure(let error):
-                self?.postOutput.send(completion: .failure(error))
-            }
-        }
+        )
         .start()
+        .sink { completion in
+            switch completion {
+            case .finished:
+                break
+            case .failure(let error):
+                dump(error)
+            }
+        } receiveValue: { [weak self] post in
+            self?.postOutput.send(post)
+        }
+        .store(in: &cancellableBag)
     }
     
     private func getUserData() {
         UserDetailUseCase(
             repository: DefaultUserDetailRepository(),
             userID: self.userID
-        ) { [weak self] result in
-            switch result {
-            case .success(let user):
-                self?.userOutput.send(user)
-            case .failure(let error):
-                self?.userOutput.send(completion: .failure(error))
-            }
-        }
+        )
         .start()
+        .sink { completion in
+            switch completion {
+            case .finished:
+                break
+            case .failure(let error):
+                dump(error)
+            }
+        } receiveValue: { [weak self] user in
+            self?.userOutput.send(user)
+        }
+        .store(in: &cancellableBag)
+
     }
     
     private func checkUser(userID: String) -> Bool {

--- a/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -137,15 +137,18 @@ final class ChatRoomViewModel {
     }
     
     func getPostData() {
-        let endpoint = APIEndPoints.getPost(id: self.postID)
-        Task {
-            do {
-                guard let data = try await APIProvider.shared.request(with: endpoint) else { return }
-                postOutput.send(data)
-            } catch let error as NetworkError {
-                postOutput.send(completion: .failure(error))
+        PostDetailUseCase(
+            repository: DefaultPostDetailRepostory(),
+            postID: self.postID
+        ) { [weak self] result in
+            switch result {
+            case .success(let post):
+                self?.postOutput.send(post)
+            case .failure(let error):
+                self?.postOutput.send(completion: .failure(error))
             }
         }
+        .start()
     }
     
     private func getUserData() {

--- a/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
+++ b/iOS/Village/Village/Presentation/ChatRoom/ViewModel/ChatRoomViewModel.swift
@@ -102,38 +102,61 @@ final class ChatRoomViewModel {
         )
     }
     
+    private func setRoom(data: ChatRoom) {
+        
+    }
+    
     func getChatRoomData() {
         ChatRoomUseCase(
             repository: DefaultChatRoomRepository(),
             roomID: self.roomID
-        ) { [weak self] result in
-            switch result {
-            case .success(let data):
-                guard let self = self else { return }
-                data.chatLog.forEach { [weak self] chat in
-                    self?.appendLog(sender: chat.sender, message: chat.message)
-                }
-                if self.postID != data.postID {
-                    self.postID = data.postID
-                    if checkUser(userID: data.user) {
-                        self.userID = data.writer
-                        self.myProfileURL = data.userProfileIMG
-                        self.opponentProfileURL = data.writerProfileIMG
-                    } else {
-                        self.userID = data.user
-                        self.myProfileURL = data.writerProfileIMG
-                        self.opponentProfileURL = data.userProfileIMG
-                    }
-                    self.getPostData()
-                    self.getUserData()
-                    self.getImageData()
-                }
+        )
+        .start()
+        .sink { completion in
+            switch completion {
+            case .finished:
+                break
             case .failure(let error):
                 dump(error)
             }
+        } receiveValue: { [weak self] data in
+            self?.setRoom(data: data)
         }
-        .start()
+        .store(in: &cancellableBag)
     }
+    
+//    func getChatRoomData() {
+//        ChatRoomUseCase(
+//            repository: DefaultChatRoomRepository(),
+//            roomID: self.roomID
+//        ) { [weak self] result in
+//            switch result {
+//            case .success(let data):
+//                guard let self = self else { return }
+//                data.chatLog.forEach { [weak self] chat in
+//                    self?.appendLog(sender: chat.sender, message: chat.message)
+//                }
+//                if self.postID != data.postID {
+//                    self.postID = data.postID
+//                    if checkUser(userID: data.user) {
+//                        self.userID = data.writer
+//                        self.myProfileURL = data.userProfileIMG
+//                        self.opponentProfileURL = data.writerProfileIMG
+//                    } else {
+//                        self.userID = data.user
+//                        self.myProfileURL = data.writerProfileIMG
+//                        self.opponentProfileURL = data.userProfileIMG
+//                    }
+//                    self.getPostData()
+//                    self.getUserData()
+//                    self.getImageData()
+//                }
+//            case .failure(let error):
+//                dump(error)
+//            }
+//        }
+//        .start()
+//    }
     
     func getPostData() {
         PostDetailUseCase(

--- a/iOS/Village/Village/Presentation/Commons/RentPostSummaryView.swift
+++ b/iOS/Village/Village/Presentation/Commons/RentPostSummaryView.swift
@@ -54,7 +54,7 @@ final class RentPostSummaryView: UIView {
         setUI()
     }
     
-    func configureData(post: PostResponseDTO) {
+    func configureData(post: PostDetail) {
         postTitleLabel.text = post.title
         setPrice(price: post.price)
         configureImageView(imageURL: post.images.first)

--- a/iOS/Village/Village/Presentation/Commons/RequestPostSummaryView.swift
+++ b/iOS/Village/Village/Presentation/Commons/RequestPostSummaryView.swift
@@ -44,7 +44,7 @@ final class RequestPostSummaryView: UIView {
         setUI()
     }
     
-    func configureData(post: PostResponseDTO) {
+    func configureData(post: PostDetail) {
         postTitleLabel.text = post.title
         
         let dateFormatter = DateFormatter()

--- a/iOS/Village/Village/Presentation/Report/ViewModel/ReportViewModel.swift
+++ b/iOS/Village/Village/Presentation/Report/ViewModel/ReportViewModel.swift
@@ -45,10 +45,17 @@ final class ReportViewModel {
         )
         let usecase = UseCase(
             repository: DefaultReportRepository(),
-            requestValue: requestValue,
-            completeOutput: completeOutput
+            requestValue: requestValue
         )
-        usecase.start()
+            .start()
+            .sink { completion in
+                switch completion {
+                case .finished:
+                    break
+                case .failure(let error):
+                    dump(error)
+                }
+            } receiveValue: {}
     }
     
 }


### PR DESCRIPTION
## 이슈
- #597 

## 체크리스트
- [x] Repository 정의
- [x] UseCase 정의

## 고민한 내용

### 이전에 고민했던 guard 구문에서 else의 return을 .success로 하는 것에 대한 고민
- .failure로 하고 .emptyData를 return하는 식으로 변경함.
- 다른 분들의 생각은 어떤 지 궁금합니다.
### ChatRoomResponse를 가져오면서 생긴 고민
- 기존의 코드는 roomID를 이용해서 접근하고, 가져온 데이터를 따로 저장하지 않고 개별적으로 필요한 데이터를 다른 함수에 주입시켰다.
- 데이터를 저장하고, 그 저장한 데이터를 기반으로 작업을 진행하는 것에 대해서 고민을 했지만 좋은 방법이 떠오르질 않음
- 프로필 이미지를 가져오는 과정에서도 비동기로 호출하여 에러가 발생하여 임의로 고침 -> 같이 고민해주세요..

