### PR TITLE
[BE/#603] 채팅방 나갔다가 들어오면 이전 채팅 안보이게 구현

### DIFF
--- a/BE/src/chat/chat.service.ts
+++ b/BE/src/chat/chat.service.ts
@@ -275,10 +275,10 @@ export class ChatService {
       where: { id: roomId },
     });
 
-    if (room.writer === userId && room.user_left !== false) {
-      room.user_left = false;
-    } else if (room.user === userId && room.writer_left !== false) {
-      room.writer_left = false;
+    if (room.writer === userId && room.user_hide !== false) {
+      room.user_hide = false;
+    } else if (room.user === userId && room.writer_hide !== false) {
+      room.writer_hide = false;
     }
     await this.chatRoomRepository.save(room);
   }
@@ -302,11 +302,29 @@ export class ChatService {
     });
 
     if (room.writer === userId) {
-      room.writer_left = true;
+      room.writer_hide = true;
     } else if (room.user === userId) {
-      room.user_left = true;
+      room.user_hide = true;
     }
 
     await this.chatRoomRepository.save(room);
   }
 }
+
+/*
+user_left_time , writer_left_time -> timestamp 혹은 dateTime 형식
+user_hide, writer_hide -> boolean 형식
+
+채팅을 보낼 때, 상대방의 hide 를 X 로 만들어준다, 
+
+채팅 목록을 보내는건 hide 가 X 이고 user_left_time 이후,  혹은 null 일 경우 전부 보내준다
+채팅방 목록은 hide 가 X 인 것만 보내준다.
+
+1. user 나감 -> user_hide -> O, user_left_time -> now()
+
+2. writer 가 다시 보냄 -> user_hide -> X 
+
+3. 나가기 -> hide -> O, left_time -> now()
+
+이렇게 처리해도 될듯? user_left_time = now()
+*/

--- a/BE/src/chat/chat.service.ts
+++ b/BE/src/chat/chat.service.ts
@@ -303,8 +303,10 @@ export class ChatService {
 
     if (room.writer === userId) {
       room.writer_hide = true;
+      room.writer_left_time = new Date();
     } else if (room.user === userId) {
       room.user_hide = true;
+      room.user_left_time = new Date();
     }
 
     await this.chatRoomRepository.save(room);

--- a/BE/src/chat/chat.service.ts
+++ b/BE/src/chat/chat.service.ts
@@ -217,6 +217,19 @@ export class ChatService {
       .execute();
   }
 
+  /*async getRoomAndChatInfoPagination(roomId: number, chatId: number) {
+    return await this.chatRoomRepository
+      .createQueryBuilder('chat_room')
+      .innerJoinAndSelect('chat_room.chats', 'chat_info')
+      .innerJoinAndSelect('chat_room.writerUser', 'writer')
+      .innerJoinAndSelect('chat_room.userUser', 'user')
+      .where('chat_room.id = :roomId', { roomId: roomId })
+      .andWhere('chat_info.id < :chatId', { chatId: chatId })
+      .orderBy('chat_info.id', 'DESC')
+      .limit(30)
+      .getOne();
+  }*/
+
   async getRoomAndChatInfo(roomId: number, userId: string) {
     return await this.chatRoomRepository.findOne({
       where: {
@@ -224,15 +237,6 @@ export class ChatService {
       },
       relations: ['chats', 'userUser', 'writerUser'],
     });
-    /*return await this.chatRoomRepository
-      .createQueryBuilder('chat_room')
-      .innerJoinAndSelect('chat_room.chats', 'chat_info')
-      .innerJoinAndSelect('chat_room.writerUser', 'writer')
-      .innerJoinAndSelect('chat_room.userUser', 'user')
-      .where('chat_room.id = :roomId', { roomId: roomId })
-      .andWhere('chat_info.id < 450374')
-      .limit(5)
-      .getOne();*/
   }
 
   async findRoomById(roomId: number, userId: string) {

--- a/BE/src/chat/chat.service.ts
+++ b/BE/src/chat/chat.service.ts
@@ -212,7 +212,7 @@ export class ChatService {
       .update()
       .set({ is_read: true })
       .where('chat.chat_room = :roomId', { roomId: roomId })
-      //.andWhere('chat.is_read = :isRead', { isRead: false })
+      .andWhere('chat.is_read = :isRead', { isRead: false })
       .andWhere('chat.sender != :userId', { userId: userId })
       .execute();
 
@@ -332,21 +332,3 @@ export class ChatService {
     await this.chatRoomRepository.save(room);
   }
 }
-
-/*
-user_left_time , writer_left_time -> timestamp 혹은 dateTime 형식
-user_hide, writer_hide -> boolean 형식
-
-채팅을 보낼 때, 상대방의 hide 를 X 로 만들어준다, 
-
-채팅 목록을 보내는건 hide 가 X 이고 user_left_time 이후,  혹은 null 일 경우 전부 보내준다
-채팅방 목록은 hide 가 X 인 것만 보내준다.
-
-1. user 나감 -> user_hide -> O, user_left_time -> now()
-
-2. writer 가 다시 보냄 -> user_hide -> X 
-
-3. 나가기 -> hide -> O, left_time -> now()
-
-이렇게 처리해도 될듯? user_left_time = now()
-*/

--- a/BE/src/chat/chat.service.ts
+++ b/BE/src/chat/chat.service.ts
@@ -224,6 +224,15 @@ export class ChatService {
       },
       relations: ['chats', 'userUser', 'writerUser'],
     });
+    /*return await this.chatRoomRepository
+      .createQueryBuilder('chat_room')
+      .innerJoinAndSelect('chat_room.chats', 'chat_info')
+      .innerJoinAndSelect('chat_room.writerUser', 'writer')
+      .innerJoinAndSelect('chat_room.userUser', 'user')
+      .where('chat_room.id = :roomId', { roomId: roomId })
+      .andWhere('chat_info.id < 450374')
+      .limit(5)
+      .getOne();*/
   }
 
   async findRoomById(roomId: number, userId: string) {

--- a/BE/src/chat/chat.service.ts
+++ b/BE/src/chat/chat.service.ts
@@ -275,9 +275,9 @@ export class ChatService {
     } else if (room.writer !== userId && room.user !== userId) {
       throw new HttpException('권한이 없습니다.', 403);
     } else if (room.writer === userId && room.writer_hide === true) {
-      throw new HttpException('채팅방이 존재하지 않습니다.', 404);
+      throw new HttpException('숨긴 채팅방입니다.', 403);
     } else if (room.user === userId && room.user_hide === true) {
-      throw new HttpException('채팅방이 존재하지 않습니다.', 404);
+      throw new HttpException('숨긴 채팅방입니다.', 403);
     }
   }
 

--- a/BE/src/entities/chatRoom.entity.ts
+++ b/BE/src/entities/chatRoom.entity.ts
@@ -47,10 +47,16 @@ export class ChatRoomEntity {
   last_chat_id: number;
 
   @Column({ default: false })
-  writer_left: boolean;
+  writer_hide: boolean;
 
   @Column({ default: false })
-  user_left: boolean;
+  user_hide: boolean;
+
+  @Column({ default: null, type: 'timestamp' })
+  writer_left_time: Date;
+
+  @Column({ default: null, type: 'timestamp' })
+  user_left_time: Date;
 
   @OneToMany(() => ChatEntity, (chat) => chat.chatRoom)
   chats: ChatEntity[];


### PR DESCRIPTION
## 이슈
- #603 

## 체크리스트
- [x] 채팅방 나가기 
- [x] 돌아오면 이전 채팅 안보임

## 구현

1. writer_hide 와 user_hide 는 writer 와 user 에게 현재 채팅방이 채팅방 목록에 뜨나 안 뜨나 를 나타낸다.
2. writer_left_time 과 user_left_time 은 마지막으로 writer 와 user 가 각각 마지막으x로 채팅방을 언제 나갔는지를 나타낸다.

- 기본적으로는 x_hide 는 false , x_left_time 은 null 이다. 
- 현재 내가 user 라고 가정하고 내가 채팅방을 나가면, user_hide 는 true , user_left_time 은 현재 시각이 기록된다. 
- 이후에 만약 상대방이 다시 채팅을 보내는 경우, user_hide 는 false 로 변한다. user_left_time 은 그대로 두는데 이는 내가 어느 채팅부터 확인해야하는지 확인하기 위해서이다.

- 채팅 목록을 가져올때는 user_left_time 이후의 채팅목록만 가져온다.
- 채팅방 목록을 가져올때는, user_hide 가 false 인 것만 가져온다. user_left_time 은 신경쓰지 않는다.
